### PR TITLE
feat: add assemble API

### DIFF
--- a/src/mvp_dataset/core/__init__.py
+++ b/src/mvp_dataset/core/__init__.py
@@ -1,6 +1,7 @@
 """Core shared types and primitives."""
 
 from .types import (
+    Assembler,
     GroupedSample,
     PathLikeStr,
     RefFieldSpec,
@@ -11,6 +12,7 @@ from .types import (
 )
 
 __all__ = [
+    "Assembler",
     "GroupedSample",
     "PathLikeStr",
     "RefFieldSpec",

--- a/src/mvp_dataset/core/types.py
+++ b/src/mvp_dataset/core/types.py
@@ -6,6 +6,7 @@ import importlib
 import os
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
+from typing import Protocol
 
 # ---------------------------------------------------------------------------
 # Shared aliases
@@ -34,6 +35,16 @@ RefFieldSpec = tuple[str, PathLikeStr]
 
 Stage = Callable[[Iterable[object]], Iterable[object]]
 """One lazy transformation stage in the iterator pipeline."""
+
+
+class Assembler[T, U](Protocol):
+    """Stateful stream assembler that may emit outputs after consuming inputs."""
+
+    def push(self, sample: T) -> Iterable[U]:
+        """Consume one upstream sample and yield any completed outputs."""
+
+    def finish(self, *, drop_last: bool = False) -> Iterable[U]:
+        """Flush remaining state at end of stream."""
 
 
 def _read_torch_runtime_values() -> tuple[int | None, int | None, int | None, int | None]:

--- a/src/mvp_dataset/pipeline/__init__.py
+++ b/src/mvp_dataset/pipeline/__init__.py
@@ -1,6 +1,12 @@
 """Pipeline abstractions and transformation operations."""
 
 from .dataset import Dataset
-from .ops import batch_samples, map_samples, shuffle_samples, unbatch_samples
+from .ops import (
+    assemble_samples,
+    batch_samples,
+    map_samples,
+    shuffle_samples,
+    unbatch_samples,
+)
 
-__all__ = ["Dataset", "batch_samples", "map_samples", "shuffle_samples", "unbatch_samples"]
+__all__ = ["Dataset", "assemble_samples", "batch_samples", "map_samples", "shuffle_samples", "unbatch_samples"]

--- a/src/mvp_dataset/pipeline/dataset.py
+++ b/src/mvp_dataset/pipeline/dataset.py
@@ -10,12 +10,25 @@ from dataclasses import dataclass
 from types import ModuleType
 from typing import Literal, cast
 
-from ..core.types import RefFieldSpec, RuntimeContext, ShardInput, SidecarSpec, Stage
+from ..core.types import (
+    Assembler,
+    RefFieldSpec,
+    RuntimeContext,
+    ShardInput,
+    SidecarSpec,
+    Stage,
+)
 from ..sources import iter_jsonls, iter_tars
 from ..sources.jsonl import materialize_jsonl_shards
 from ..utils.sharding import iter_items
 from ..utils.url import normalize_paths
-from .ops import batch_samples, map_samples, shuffle_samples, unbatch_samples
+from .ops import (
+    assemble_samples,
+    batch_samples,
+    map_samples,
+    shuffle_samples,
+    unbatch_samples,
+)
 
 SourceKind = Literal["jsonl", "tars"]
 SourceStore = list[str]
@@ -421,6 +434,34 @@ class Dataset(torch_iterabledataset_class()):
                 batch_size=batch_size,
                 drop_last=drop_last,
                 collate_fn=collate_fn,
+            )
+
+        return self._append_stage(stage)
+
+    def assemble(
+        self,
+        factory: Callable[[RuntimeContext], Assembler[object, object]],
+        *,
+        drop_last: bool = False,
+    ) -> Dataset:
+        """Append a stateful assembly stage.
+
+        Args:
+            factory: Callable that builds one fresh assembler for each iterator
+                execution. The assembler may consume multiple upstream samples
+                before yielding one or more downstream outputs.
+            drop_last: Whether to discard unfinished tail state instead of
+                delegating it to the assembler's final flush.
+
+        Returns:
+            A new dataset that assembles the upstream sample stream lazily.
+        """
+
+        def stage(data: Iterable[object]) -> Iterable[object]:
+            return assemble_samples(
+                data,
+                factory=lambda: factory(self.context),
+                drop_last=drop_last,
             )
 
         return self._append_stage(stage)

--- a/src/mvp_dataset/pipeline/ops.py
+++ b/src/mvp_dataset/pipeline/ops.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import random
 from collections.abc import Callable, Iterable, Iterator
 
+from ..core.types import Assembler
+
 
 def map_samples[T, U](data: Iterable[T], fn: Callable[[T], U]) -> Iterator[U]:
     """Lazily apply ``fn`` to each sample in ``data``."""
@@ -87,6 +89,20 @@ def batch_samples[T, U](
 
     if batch and not drop_last:
         yield collate_fn(batch) if collate_fn is not None else list(batch)
+
+
+def assemble_samples[T, U](
+    data: Iterable[T],
+    *,
+    factory: Callable[[], Assembler[T, U]],
+    drop_last: bool = False,
+) -> Iterator[U]:
+    """Assemble a stream with stateful many-to-one or many-to-many logic."""
+
+    assembler = factory()
+    for sample in data:
+        yield from assembler.push(sample)
+    yield from assembler.finish(drop_last=drop_last)
 
 
 def unbatch_samples(data: Iterable[object]) -> Iterator[object]:


### PR DESCRIPTION
We can use this assemble API to do data packing.

Basically, `assemble` means `many to one`.

We consume multiple data samples in this stage and construct a single one as the output.

Users just need to provide a assembler.