### PR TITLE
feat: add Dataset.cache() API with per-field signature tracking

### DIFF
--- a/examples/cache_demo.py
+++ b/examples/cache_demo.py
@@ -1,0 +1,238 @@
+"""Demo: Dataset.cache() warm-up, reuse, invalidation, and groups.
+
+Run:
+    python examples/cache_demo.py
+
+This script creates temporary tar shards, then walks through four scenarios
+to illustrate how the cache layer works end-to-end.
+"""
+
+from __future__ import annotations
+
+import io
+import shutil
+import tarfile
+import tempfile
+import time
+from pathlib import Path
+
+from mvp_dataset import Dataset
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_tar(path: Path, samples: list[dict]) -> None:
+    """Write samples to a tar using the ``{key}.{field}`` naming convention."""
+    with tarfile.open(str(path), "w") as tf:
+        for sample in samples:
+            key = sample["__key__"]
+            for field, value in sample.items():
+                if field.startswith("__") and field.endswith("__"):
+                    continue
+                data = value if isinstance(value, bytes) else str(value).encode()
+                ti = tarfile.TarInfo(name=f"{key}.{field}")
+                ti.size = len(data)
+                tf.addfile(ti, io.BytesIO(data))
+
+
+def section(title: str) -> None:
+    print(f"\n{'=' * 60}")
+    print(f"  {title}")
+    print(f"{'=' * 60}\n")
+
+
+# ---------------------------------------------------------------------------
+# Setup: create two tar shards with image + label fields
+# ---------------------------------------------------------------------------
+
+tmpdir = Path(tempfile.mkdtemp(prefix="cache_demo_"))
+print(f"Working directory: {tmpdir}\n")
+
+shard_0 = tmpdir / "shard-00000.tar"
+shard_1 = tmpdir / "shard-00001.tar"
+
+make_tar(
+    shard_0,
+    [
+        {"__key__": "0001", "image": b"\x89PNG_fake_img_1", "label": b"cat"},
+        {"__key__": "0002", "image": b"\x89PNG_fake_img_2", "label": b"dog"},
+    ],
+)
+make_tar(
+    shard_1,
+    [
+        {"__key__": "0003", "image": b"\x89PNG_fake_img_3", "label": b"bird"},
+    ],
+)
+
+tar_paths = [str(shard_0), str(shard_1)]
+
+# ---------------------------------------------------------------------------
+# Scenario 1: First iteration builds cache, second reuses it
+# ---------------------------------------------------------------------------
+
+section("1. Cache build & reuse")
+
+call_count = 0
+
+
+def preprocess(sample):
+    global call_count
+    call_count += 1
+    return {**sample, "tag": b"processed"}
+
+
+ds = Dataset.from_tars(tar_paths).map(preprocess).cache()
+
+t0 = time.perf_counter()
+samples_1 = list(ds)
+dt_build = time.perf_counter() - t0
+print(f"First  iter: {len(samples_1)} samples, map called {call_count}x  ({dt_build:.4f}s)")
+
+call_count = 0
+t0 = time.perf_counter()
+samples_2 = list(ds)
+dt_reuse = time.perf_counter() - t0
+print(f"Second iter: {len(samples_2)} samples, map called {call_count}x  ({dt_reuse:.4f}s)")
+print("  -> map was NOT called on reuse: cache hit!")
+
+# Show cache directory layout
+cache_dir = tmpdir / ".cache"
+print(f"\nCache directory: {cache_dir}")
+for f in sorted(cache_dir.iterdir()):
+    print(f"  {f.name}  ({f.stat().st_size} bytes)")
+
+# ---------------------------------------------------------------------------
+# Scenario 2: Changing the map function invalidates the cache
+# ---------------------------------------------------------------------------
+
+section("2. Cache invalidation on function change")
+
+
+def preprocess_v2(sample):
+    return {**sample, "tag": b"v2"}
+
+
+ds_v2 = Dataset.from_tars(tar_paths).map(preprocess_v2).cache()
+samples_v2 = list(ds_v2)
+
+print(f"v1 tag: {samples_1[0]['tag']}")
+print(f"v2 tag: {samples_v2[0]['tag']}")
+
+all_tars = sorted(cache_dir.glob("*.tar"))
+print(f"\nCache tars now ({len(all_tars)} total, v1 + v2 coexist):")
+for f in all_tars:
+    print(f"  {f.name}")
+
+# ---------------------------------------------------------------------------
+# Scenario 3: Field grouping — split fields into separate tars
+# ---------------------------------------------------------------------------
+
+section("3. Explicit groups: [image, label] vs auto-singleton")
+
+# Clean up old cache
+shutil.rmtree(cache_dir, ignore_errors=True)
+
+ds_grouped = (
+    Dataset.from_tars(tar_paths)
+    .map(preprocess)
+    .cache(
+        groups=[["image"], ["label"]],  # "tag" field auto-becomes singleton
+    )
+)
+list(ds_grouped)
+
+group_tars = sorted(cache_dir.glob("*.tar"))
+print(f"Group tars per shard ({len(group_tars)} total):")
+for f in group_tars:
+    print(f"  {f.name}")
+print("  -> 'image', 'label', 'tag' each in their own tar per shard")
+
+# ---------------------------------------------------------------------------
+# Scenario 4: Post-cache stages run every iteration
+# ---------------------------------------------------------------------------
+
+section("4. Post-cache stages")
+
+shutil.rmtree(cache_dir, ignore_errors=True)
+
+post_count = 0
+
+
+def post_fn(sample):
+    global post_count
+    post_count += 1
+    return {**sample, "extra": b"post"}
+
+
+ds_post = (
+    Dataset.from_tars(tar_paths)
+    .map(preprocess)
+    .cache()  # <-- boundary
+    .map(post_fn)  # <-- runs every iteration, not cached
+)
+
+list(ds_post)
+print(f"After 1st iter: post_fn called {post_count}x")
+
+post_count = 0
+result = list(ds_post)
+print(f"After 2nd iter: post_fn called {post_count}x  (still runs!)")
+print(f"  sample keys: {[s['__key__'] for s in result]}")
+print(f"  extra field: {result[0]['extra']}")
+
+# ---------------------------------------------------------------------------
+# Scenario 5: Expensive map — cache gives massive speedup
+# ---------------------------------------------------------------------------
+
+section("5. Expensive map: cache speedup")
+
+shutil.rmtree(cache_dir, ignore_errors=True)
+
+# Create a larger shard with 200 samples
+big_shard = tmpdir / "big-shard-00000.tar"
+make_tar(
+    big_shard,
+    [{"__key__": f"{i:04d}", "image": bytes(range(256)) * 4, "label": f"cls_{i % 10}".encode()} for i in range(200)],
+)
+
+
+def expensive_map(sample):
+    """Simulate a heavy preprocessing step (resize, augment, tokenize, etc.)."""
+    img = sample["image"]
+    # Burn ~10ms per sample with redundant hashing
+    import hashlib
+
+    acc = img
+    for _ in range(2000):
+        acc = hashlib.sha256(acc).digest()
+    return {**sample, "feature": acc}
+
+
+ds_expensive = Dataset.from_tars([str(big_shard)]).map(expensive_map).cache()
+
+t0 = time.perf_counter()
+r1 = list(ds_expensive)
+dt_cold = time.perf_counter() - t0
+
+t0 = time.perf_counter()
+r2 = list(ds_expensive)
+dt_hot = time.perf_counter() - t0
+
+speedup = dt_cold / dt_hot if dt_hot > 0 else float("inf")
+print(f"Cold (build cache): {dt_cold:.3f}s  ({len(r1)} samples)")
+print(f"Hot  (read cache):  {dt_hot:.3f}s  ({len(r2)} samples)")
+print(f"Speedup:            {speedup:.1f}x")
+assert r1[0]["feature"] == r2[0]["feature"], "round-trip mismatch!"
+print("  -> Round-trip verified: cached values match original.")
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+section("Done")
+print(f"Cleaning up {tmpdir}")
+# shutil.rmtree(tmpdir)
+print("All clean.")

--- a/src/mvp_dataset/cache/__init__.py
+++ b/src/mvp_dataset/cache/__init__.py
@@ -1,0 +1,1 @@
+"""Cache materialization and serving for Dataset pipelines."""

--- a/src/mvp_dataset/cache/codecs.py
+++ b/src/mvp_dataset/cache/codecs.py
@@ -1,0 +1,128 @@
+"""Value codecs for cache tar storage.
+
+Codec tags
+----------
+``raw``        bytes / bytearray  — stored as-is
+``utf8``       str                — UTF-8 encoded
+``json``       JSON-compatible scalars and containers
+``npy``        numpy.ndarray      — stored via numpy.save
+``npy_tensor`` torch.Tensor       — converted to CPU, stored via numpy.save
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from typing import Any
+
+CODEC_RAW = "raw"
+CODEC_UTF8 = "utf8"
+CODEC_JSON = "json"
+CODEC_NPY = "npy"
+CODEC_NPY_TENSOR = "npy_tensor"
+
+
+def encode_value(value: Any) -> tuple[bytes, str]:
+    """Encode *value* for storage in a cache tar.
+
+    Args:
+        value: The Python value to encode.  See the module docstring for
+            the supported type matrix.
+
+    Returns:
+        A ``(data_bytes, codec_tag)`` tuple where *codec_tag* identifies
+        the encoding used.
+
+    Raises:
+        TypeError: If *value* has an unsupported type.
+    """
+    if isinstance(value, (bytes, bytearray)):
+        return bytes(value), CODEC_RAW
+
+    if isinstance(value, str):
+        return value.encode("utf-8"), CODEC_UTF8
+
+    if _is_json_compatible(value):
+        return (
+            json.dumps(value, ensure_ascii=True, separators=(",", ":")).encode("utf-8"),
+            CODEC_JSON,
+        )
+
+    try:
+        import numpy as np
+
+        if isinstance(value, np.ndarray):
+            buf = io.BytesIO()
+            np.save(buf, value, allow_pickle=False)
+            return buf.getvalue(), CODEC_NPY
+    except ImportError:
+        pass
+
+    try:
+        import numpy as np
+        import torch
+
+        if isinstance(value, torch.Tensor):
+            arr = value.cpu().numpy()
+            buf = io.BytesIO()
+            np.save(buf, arr, allow_pickle=False)
+            return buf.getvalue(), CODEC_NPY_TENSOR
+    except ImportError:
+        pass
+
+    msg = (
+        f"[CacheCodecError] unsupported value type {type(value).__name__!r}; "
+        f"supported: bytes, str, JSON-compatible scalars/containers, "
+        f"numpy.ndarray, torch.Tensor"
+    )
+    raise TypeError(msg)
+
+
+def decode_value(data: bytes, codec_tag: str) -> Any:
+    """Decode *data* using *codec_tag* back to the original Python value.
+
+    Args:
+        data: Raw bytes read from a cache tar member.
+        codec_tag: The codec identifier stored alongside the data
+            (e.g. ``"raw"``, ``"utf8"``, ``"json"``, ``"npy"``,
+            ``"npy_tensor"``).
+
+    Returns:
+        The decoded Python value.
+
+    Raises:
+        ValueError: If *codec_tag* is not recognized.
+    """
+    if codec_tag == CODEC_RAW:
+        return data
+
+    if codec_tag == CODEC_UTF8:
+        return data.decode("utf-8")
+
+    if codec_tag == CODEC_JSON:
+        return json.loads(data.decode("utf-8"))
+
+    if codec_tag == CODEC_NPY:
+        import numpy as np
+
+        return np.load(io.BytesIO(data), allow_pickle=False)
+
+    if codec_tag == CODEC_NPY_TENSOR:
+        import numpy as np
+        import torch
+
+        arr = np.load(io.BytesIO(data), allow_pickle=False)
+        return torch.from_numpy(arr)
+
+    msg = f"[CacheCodecError] unknown codec tag {codec_tag!r}"
+    raise ValueError(msg)
+
+
+def _is_json_compatible(value: Any) -> bool:
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return True
+    if isinstance(value, (list, tuple)):
+        return all(_is_json_compatible(v) for v in value)
+    if isinstance(value, dict):
+        return all(isinstance(k, str) and _is_json_compatible(v) for k, v in value.items())
+    return False

--- a/src/mvp_dataset/cache/fingerprint.py
+++ b/src/mvp_dataset/cache/fingerprint.py
@@ -1,0 +1,165 @@
+"""Stable fingerprinting utilities for callables and composite values."""
+
+from __future__ import annotations
+
+import functools
+import hashlib
+import struct
+import types
+from collections.abc import Callable
+from typing import Any
+
+
+def hash_bytes(*parts: Any) -> str:
+    """Return a SHA-256 hex digest over a sequence of typed parts.
+
+    Each part is type-tagged and length-prefixed so that adjacent parts
+    cannot collide.
+
+    Args:
+        *parts: Values to hash.  Supported types: ``bytes``, ``str``,
+            ``int``, ``float``, ``bool``.
+
+    Returns:
+        A 64-character lowercase hex digest string.
+
+    Raises:
+        TypeError: If any part has an unsupported type.
+    """
+    h = hashlib.sha256()
+    for part in parts:
+        if isinstance(part, (bytes, bytearray)):
+            data = bytes(part)
+            h.update(b"B")
+            h.update(struct.pack(">Q", len(data)))
+            h.update(data)
+        elif isinstance(part, bool):
+            h.update(b"b")
+            h.update(b"\x01" if part else b"\x00")
+        elif isinstance(part, int):
+            h.update(b"I")
+            h.update(struct.pack(">q", part))
+        elif isinstance(part, float):
+            h.update(b"F")
+            h.update(struct.pack(">d", part))
+        elif isinstance(part, str):
+            encoded = part.encode("utf-8")
+            h.update(b"S")
+            h.update(struct.pack(">Q", len(encoded)))
+            h.update(encoded)
+        else:
+            raise TypeError(f"unsupported hash part type {type(part)!r}")
+    return h.hexdigest()
+
+
+def callable_fingerprint(fn: Callable[..., Any]) -> str:
+    """Return a stable fingerprint for a Python callable.
+
+    Covers: bytecode, filename, name, defaults, kwdefaults, and closure cell
+    contents.
+
+    Args:
+        fn: The callable to fingerprint.  May be a function, lambda,
+            :class:`functools.partial`, or any object with a ``__code__``
+            attribute.
+
+    Returns:
+        A 64-character hex digest uniquely identifying the callable's
+        logic and captured state.
+
+    Raises:
+        ValueError: If a closure cell contains a value that cannot be
+            stably encoded (e.g. an arbitrary object instance).
+    """
+    parts: list[Any] = []
+    _collect_callable(fn, parts, seen=set())
+    return hash_bytes(*parts)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _collect_callable(fn: Any, parts: list[Any], seen: set[int]) -> None:
+    fn_id = id(fn)
+    if fn_id in seen:
+        parts.append(b"<recursive>")
+        return
+    seen.add(fn_id)
+
+    if isinstance(fn, functools.partial):
+        parts.append(b"<partial>")
+        for arg in fn.args:
+            _collect_value(arg, parts)
+        for k in sorted(fn.keywords):
+            parts.append(k)
+            _collect_value(fn.keywords[k], parts)
+        _collect_callable(fn.func, parts, seen)
+        return
+
+    code = getattr(fn, "__code__", None)
+    if code is None:
+        # Built-in or extension callable: use qualified name as proxy.
+        parts.append(f"{type(fn).__module__}.{type(fn).__qualname__}")
+        return
+
+    raw_bytecode = code.co_code if isinstance(code.co_code, bytes) else bytes(code.co_code)
+    parts.append(raw_bytecode)
+    parts.append(code.co_filename)
+    parts.append(code.co_name)
+
+    for d in getattr(fn, "__defaults__", None) or ():
+        _collect_value(d, parts)
+    for k in sorted(getattr(fn, "__kwdefaults__", None) or {}):
+        parts.append(k)
+        _collect_value((fn.__kwdefaults__ or {})[k], parts)
+
+    for cell in getattr(fn, "__closure__", None) or ():
+        try:
+            val = cell.cell_contents
+        except ValueError:
+            continue  # empty cell
+        _collect_value(val, parts)
+
+
+def _collect_value(val: Any, parts: list[Any]) -> None:
+    """Encode a scalar-ish value into *parts* for hashing.
+
+    Raises :class:`ValueError` for values that cannot be stably encoded.
+    """
+    if val is None:
+        parts.append(b"\x00None")
+    elif isinstance(val, bool):
+        parts.append(b"\x01True" if val else b"\x01False")
+    elif isinstance(val, int):
+        parts.append(val)
+    elif isinstance(val, float):
+        parts.append(val)
+    elif isinstance(val, str):
+        parts.append(val)
+    elif isinstance(val, (bytes, bytearray)):
+        parts.append(bytes(val))
+    elif isinstance(val, (list, tuple)):
+        parts.append(b"<seq>")
+        for item in val:
+            _collect_value(item, parts)
+        parts.append(b"</seq>")
+    elif isinstance(val, dict):
+        parts.append(b"<dict>")
+        for k in sorted(str(k) for k in val):
+            parts.append(k)
+            _collect_value(val[k], parts)  # type: ignore[index]
+        parts.append(b"</dict>")
+    elif isinstance(val, types.ModuleType):
+        # Represent a module by its fully-qualified name.
+        parts.append(f"<module:{val.__name__}>")
+    elif callable(val):
+        _collect_callable(val, parts, seen=set())
+    else:
+        msg = (
+            f"[CacheFingerprintError] cannot stably encode closure value of type "
+            f"{type(val).__name__!r}; supported: None, bool, int, float, str, bytes, "
+            f"list, tuple, dict, module, or callable"
+        )
+        raise ValueError(msg)

--- a/src/mvp_dataset/cache/materialize.py
+++ b/src/mvp_dataset/cache/materialize.py
@@ -1,0 +1,843 @@
+"""Cache materialization: source annotation, warm-up, manifest, and read path."""
+
+from __future__ import annotations
+
+import fcntl
+import io
+import itertools
+import json
+import os
+import sys
+import tarfile
+import warnings
+from collections.abc import Callable, Iterable, Iterator, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final
+
+from ..core.types import RefFieldSpec, Sample, SidecarSpec
+from ..sources.jsonl import TarManager, _parse_jsonl_line, parse_tar_uri
+from ..sources.tar import iter_tar
+from .codecs import decode_value, encode_value
+from .fingerprint import hash_bytes
+
+# Reserved meta member suffix inside cache tars (e.g. "0001.__cache_meta__")
+_CACHE_META_SUFFIX: Final[str] = ".__cache_meta__"
+# Key used inside sample dicts to carry per-sample cache metadata through pipeline
+_CACHE_META_KEY: Final[str] = "__cache_meta__"
+
+
+def _is_meta_field(name: str) -> bool:
+    """Return True for dunder metadata fields (e.g. ``__key__``)."""
+    return name.startswith("__") and name.endswith("__")
+
+
+# ---------------------------------------------------------------------------
+# Per-sample cache metadata
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CacheMeta:
+    """Cache metadata carried inside a sample through the pre-cache stages."""
+
+    route_shard: str
+    """Source shard path that this sample is attributed to for cache routing."""
+
+    field_sigs: dict[str, str]
+    """Content-addressable signature per user field (field_name -> hex digest)."""
+
+
+# ---------------------------------------------------------------------------
+# Group normalization
+# ---------------------------------------------------------------------------
+
+
+def normalize_groups(
+    groups_spec: tuple[tuple[str, ...], ...] | None,
+    sample_keys: Iterable[str],
+) -> list[tuple[str, ...]]:
+    """Resolve a groups spec against the actual sample keys.
+
+    Args:
+        groups_spec: Explicit field grouping, or ``None`` for a single
+            group containing all non-metadata keys.
+        sample_keys: Field names present in the first sample.
+
+    Returns:
+        A list of field-name tuples; each tuple becomes one cache tar.
+        With ``groups_spec=None`` all non-meta keys form one group.
+        With an explicit spec, uncovered non-meta keys become singletons.
+    """
+    non_meta = [k for k in sample_keys if not _is_meta_field(k)]
+
+    if groups_spec is None:
+        return [tuple(non_meta)] if non_meta else []
+
+    covered: set[str] = set()
+    result: list[tuple[str, ...]] = []
+    for group in groups_spec:
+        fields = tuple(f for f in group if f in non_meta)
+        if fields:
+            result.append(fields)
+            covered.update(fields)
+
+    for key in non_meta:
+        if key not in covered:
+            result.append((key,))
+
+    return result
+
+
+def _group_label(field_names: tuple[str, ...]) -> str:
+    """Build a human-readable label for a field group.
+
+    Args:
+        field_names: Sorted field names in the group.
+
+    Returns:
+        A ``+``-joined label (e.g. ``"depth+image"``), or a 16-char hash
+        prefix when the label exceeds 48 characters.
+    """
+    label = "+".join(sorted(field_names))
+    if len(label) > 48:
+        return hash_bytes(label)[:16]
+    return label
+
+
+# ---------------------------------------------------------------------------
+# Manifest and locking
+# ---------------------------------------------------------------------------
+
+
+def _cache_dir(shard_path: str) -> Path:
+    """Return the ``.cache/`` directory co-located with *shard_path*."""
+    return Path(shard_path).parent / ".cache"
+
+
+def _manifest_path(shard_path: str) -> Path:
+    """Return the manifest JSON path for *shard_path*."""
+    return _cache_dir(shard_path) / f"{Path(shard_path).name}.manifest.json"
+
+
+def _lock_path(shard_path: str) -> Path:
+    """Return the lock file path for *shard_path*."""
+    return _cache_dir(shard_path) / f"{Path(shard_path).name}.lock"
+
+
+def read_manifest(shard_path: str, plan_fingerprint: str) -> dict[str, str] | None:
+    """Read and validate a cache manifest for *shard_path*.
+
+    Args:
+        shard_path: Path to the original source shard.
+        plan_fingerprint: Expected plan fingerprint to match against.
+
+    Returns:
+        A ``{group_label: tar_path}`` mapping if a valid manifest exists
+        with matching fingerprint and all referenced tar files present,
+        otherwise ``None``.
+    """
+    mp = _manifest_path(shard_path)
+    if not mp.is_file():
+        return None
+    try:
+        with mp.open(encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (json.JSONDecodeError, OSError):
+        return None
+    if data.get("plan_fingerprint") != plan_fingerprint:
+        return None
+    groups: dict[str, str] = data.get("groups", {})
+    if not all(Path(tp).is_file() for tp in groups.values()):
+        return None
+    return groups
+
+
+def _write_manifest(shard_path: str, plan_fingerprint: str, groups: dict[str, str]) -> None:
+    """Atomically write a cache manifest mapping group labels to tar paths.
+
+    Args:
+        shard_path: Path to the original source shard.
+        plan_fingerprint: Plan fingerprint stored in the manifest.
+        groups: Mapping of group label to cache tar path.
+    """
+    mp = _manifest_path(shard_path)
+    mp.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "plan_fingerprint": plan_fingerprint,
+        "source_shard": shard_path,
+        "groups": groups,
+    }
+    tmp = mp.with_suffix(".tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        json.dump(payload, fh, indent=2, sort_keys=True)
+    tmp.rename(mp)
+
+
+class _ShardLock:
+    """Context manager that acquires an exclusive flock on a per-shard lock file."""
+
+    def __init__(self, shard_path: str) -> None:
+        lp = _lock_path(shard_path)
+        lp.parent.mkdir(parents=True, exist_ok=True)
+        self._path = lp
+        self._fh: io.IOBase | None = None
+
+    def __enter__(self) -> _ShardLock:
+        self._fh = self._path.open("w")
+        fcntl.flock(self._fh, fcntl.LOCK_EX)
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        if self._fh is not None:
+            fcntl.flock(self._fh, fcntl.LOCK_UN)
+            self._fh.close()
+            self._fh = None
+
+
+# ---------------------------------------------------------------------------
+# Source iteration with signature annotation
+# ---------------------------------------------------------------------------
+
+
+def iter_tars_with_sigs(
+    shard_paths: Iterator[str],
+    key_dot_level: int,
+    sidecars: Sequence[SidecarSpec] | None,
+) -> Iterator[Sample]:
+    """Iterate tar shards and annotate each sample with ``__cache_meta__``.
+
+    Each field receives a source signature derived from the shard path,
+    file stat, and tar member name.  When *sidecars* are present, sidecar
+    fields get signatures from their respective sidecar tar stats.
+
+    Args:
+        shard_paths: Iterator of main tar shard paths to process.
+        key_dot_level: Number of dot-separated segments used as the
+            sample key inside tar member names.
+        sidecars: Optional sidecar specs.  Each ``(name, path_fn)`` pair
+            maps a main shard path to its corresponding sidecar tar.
+
+    Yields:
+        Sample dicts with a ``__cache_meta__`` entry containing a
+        :class:`CacheMeta` instance.
+    """
+    _SENTINEL: Final[object] = object()
+
+    for shard_path in shard_paths:
+        shard_str = str(shard_path)
+        main_stat = os.stat(shard_str)
+
+        if not sidecars:
+            for sample in iter_tar(shard_str, key_dot_level):
+                sample[_CACHE_META_KEY] = _tar_sample_meta(sample, shard_str, main_stat)
+                yield sample
+            continue
+
+        # Sidecar join – replicate iter_tars logic but track field origins.
+        sidecar_info: list[tuple[str, str, os.stat_result]] = []
+        for sc_name, sc_fn in sidecars:
+            sc_path = str(sc_fn(shard_str))
+            sc_stat = os.stat(sc_path)
+            sidecar_info.append((sc_name, sc_path, sc_stat))
+
+        main_iter = iter_tar(shard_str, key_dot_level)
+        sidecar_iters = [iter_tar(sc_path, key_dot_level) for _, sc_path, _ in sidecar_info]
+        all_iters: list[Iterator[Sample]] = [main_iter, *sidecar_iters]
+
+        for group in itertools.zip_longest(*all_iters, fillvalue=_SENTINEL):
+            if any(s is _SENTINEL for s in group):
+                msg = f"[SidecarLengthMismatch] main shard and sidecars have different sample counts in {shard_str!r}"
+                raise ValueError(msg)
+
+            main_sample: Sample = group[0]  # type: ignore[assignment]
+            main_key = str(main_sample.get("__key__", ""))
+            merged: Sample = dict(main_sample)
+
+            field_sigs: dict[str, str] = {}
+            for field in main_sample:
+                if not _is_meta_field(field):
+                    member = f"{main_key}.{field}"
+                    field_sigs[field] = hash_bytes(shard_str, main_stat.st_mtime_ns, main_stat.st_size, member)
+
+            for i, (sc_name, sc_path, sc_stat) in enumerate(sidecar_info):
+                sc_sample: Sample = group[i + 1]  # type: ignore[assignment]
+                sc_key = str(sc_sample.get("__key__", ""))
+                if sc_key != main_key:
+                    msg = (
+                        f"[SidecarKeyMismatch] main key {main_key!r} != "
+                        f"sidecar {sc_name!r} key {sc_key!r} in {shard_str!r}"
+                    )
+                    raise ValueError(msg)
+                for field, value in sc_sample.items():
+                    if _is_meta_field(field):
+                        continue
+                    if field in merged:
+                        msg = (
+                            f"[SidecarFieldConflict] field {field!r} from sidecar "
+                            f"{sc_name!r} conflicts in {shard_str!r}"
+                        )
+                        raise ValueError(msg)
+                    merged[field] = value
+                    member = f"{sc_key}.{field}"
+                    field_sigs[field] = hash_bytes(sc_path, sc_stat.st_mtime_ns, sc_stat.st_size, member)
+
+            merged[_CACHE_META_KEY] = CacheMeta(route_shard=shard_str, field_sigs=field_sigs)
+            yield merged
+
+
+def _tar_sample_meta(sample: Sample, shard_path: str, stat: os.stat_result) -> CacheMeta:
+    """Build a :class:`CacheMeta` for a plain tar sample (no sidecars).
+
+    Args:
+        sample: Decoded tar sample dict.
+        shard_path: Path to the source tar shard.
+        stat: Pre-computed ``os.stat`` result for *shard_path*.
+
+    Returns:
+        A :class:`CacheMeta` with per-field source signatures.
+    """
+    key = str(sample.get("__key__", ""))
+    field_sigs: dict[str, str] = {}
+    for field in sample:
+        if _is_meta_field(field):
+            continue
+        member = f"{key}.{field}"
+        field_sigs[field] = hash_bytes(shard_path, stat.st_mtime_ns, stat.st_size, member)
+    return CacheMeta(route_shard=shard_path, field_sigs=field_sigs)
+
+
+def iter_jsonls_with_sigs(
+    shard_paths: Iterator[str],
+    ref_fields: tuple[RefFieldSpec, ...],
+    key_dot_level: int,
+    tar_cache_size: int,
+) -> Iterator[Sample]:
+    """Iterate JSONL shards, resolve ``tar://`` refs, and annotate with ``__cache_meta__``.
+
+    Plain JSON fields receive signatures from the JSONL shard stat and
+    canonical value bytes.  Tar-referenced fields receive signatures from
+    the referenced tar shard stat and member name.
+
+    Args:
+        shard_paths: Iterator of JSONL shard file paths.
+        ref_fields: ``(field_name, base_dir)`` pairs identifying fields
+            that contain ``tar://`` URIs to resolve.
+        key_dot_level: Dot-level parameter forwarded to
+            :func:`~mvp_dataset.sources.jsonl.parse_tar_uri`.
+        tar_cache_size: LRU cache size for opened tar files.
+
+    Yields:
+        Sample dicts with resolved tar references and a
+        ``__cache_meta__`` entry.
+    """
+    ref_field_map = dict(ref_fields)
+
+    with TarManager(cache_size=tar_cache_size) as manager:
+        for shard_path in shard_paths:
+            shard_str = str(shard_path)
+            shard_stat = os.stat(shard_str)
+
+            with open(shard_str, encoding="utf-8") as fh:
+                for line_index, line in enumerate(fh):
+                    sample = _parse_jsonl_line(shard_str, line_index, line, allow_preannotated=True)
+                    field_sigs: dict[str, str] = {}
+
+                    for field, value in sample.items():
+                        if _is_meta_field(field):
+                            continue
+                        if field in ref_field_map and isinstance(value, str):
+                            # Tar-referenced field: sig from referenced tar member.
+                            try:
+                                tar_ref = parse_tar_uri(
+                                    value,
+                                    base_dir=ref_field_map[field],
+                                    key_dot_level=key_dot_level,
+                                )
+                                ref_stat = os.stat(tar_ref.shard_path)
+                                member = f"{tar_ref.key}.{tar_ref.field}"
+                                field_sigs[field] = hash_bytes(
+                                    tar_ref.shard_path,
+                                    ref_stat.st_mtime_ns,
+                                    ref_stat.st_size,
+                                    member,
+                                )
+                            except (ValueError, OSError):
+                                # Fallback to JSON-field sig on parse/stat failure.
+                                canonical = json.dumps(value, ensure_ascii=True, sort_keys=True)
+                                field_sigs[field] = hash_bytes(
+                                    shard_str,
+                                    shard_stat.st_mtime_ns,
+                                    shard_stat.st_size,
+                                    line_index,
+                                    field,
+                                    canonical,
+                                )
+                        else:
+                            canonical = json.dumps(value, ensure_ascii=True, sort_keys=True)
+                            field_sigs[field] = hash_bytes(
+                                shard_str,
+                                shard_stat.st_mtime_ns,
+                                shard_stat.st_size,
+                                line_index,
+                                field,
+                                canonical,
+                            )
+
+                    # Resolve tar refs (matching iter_jsonls behaviour).
+                    resolved = dict(sample)
+                    for field, base_dir in ref_fields:
+                        if field not in sample:
+                            continue
+                        uri = sample[field]
+                        if not isinstance(uri, str):
+                            continue
+                        try:
+                            tar_ref = parse_tar_uri(uri, base_dir=base_dir, key_dot_level=key_dot_level)
+                        except ValueError as exc:
+                            msg = f"[InvalidRefField] field={field!r} value={uri!r} reason={exc}"
+                            raise ValueError(msg) from exc
+                        resolved[field] = manager.read(tar_ref)
+
+                    resolved[_CACHE_META_KEY] = CacheMeta(
+                        route_shard=shard_str,
+                        field_sigs=field_sigs,
+                    )
+                    yield resolved
+
+
+# ---------------------------------------------------------------------------
+# Cache-aware stage wrappers
+# ---------------------------------------------------------------------------
+
+
+def make_cache_aware_map(
+    user_fn: Callable[[object], object],
+    fn_fingerprint: str,
+) -> Callable[[Iterable[object]], Iterator[object]]:
+    """Return a stage that runs *user_fn* and propagates ``__cache_meta__``.
+
+    Signature propagation rules:
+
+    * **Unchanged field** (same object identity): carries forward its old sig.
+    * **Modified field** (same name, different value): ``hash(old_sig, fn_fp)``.
+    * **New field**: ``hash(aggregate_input_sig, fn_fp, field_name)``.
+
+    Args:
+        user_fn: The user-provided map callable.
+        fn_fingerprint: Stable hash of *user_fn* used in signature
+            derivation.
+
+    Returns:
+        A stage callable ``(Iterable) -> Iterator`` that applies
+        *user_fn* and updates per-field signatures accordingly.
+    """
+
+    def _stage(data: Iterable[object]) -> Iterator[object]:
+        for sample in data:
+            if not isinstance(sample, dict) or _CACHE_META_KEY not in sample:
+                # No meta (e.g. after an unsupported stage dropped it): pass through.
+                yield user_fn(sample)
+                continue
+
+            meta: CacheMeta = sample[_CACHE_META_KEY]
+            clean = {k: v for k, v in sample.items() if k != _CACHE_META_KEY}
+            output = user_fn(clean)
+
+            if not isinstance(output, dict):
+                yield output  # boundary check happens later
+                continue
+
+            # Compute aggregate input sig for new-field signatures.
+            agg_input_sig = hash_bytes(*sorted(meta.field_sigs.values()))
+
+            new_sigs: dict[str, str] = {}
+            for field, value in output.items():
+                if _is_meta_field(field):
+                    continue
+                if field in clean and value is clean[field]:
+                    # Unchanged object identity: carry forward old signature.
+                    new_sigs[field] = meta.field_sigs.get(field, "")
+                elif field in clean and field in meta.field_sigs:
+                    # Same field name, different value.
+                    new_sigs[field] = hash_bytes(meta.field_sigs[field], fn_fingerprint)
+                else:
+                    # New field introduced by this map fn.
+                    new_sigs[field] = hash_bytes(agg_input_sig, fn_fingerprint, field)
+
+            output[_CACHE_META_KEY] = CacheMeta(
+                route_shard=meta.route_shard,
+                field_sigs=new_sigs,
+            )
+            yield output
+
+    return _stage
+
+
+def make_cache_aware_assemble(
+    assembler_factory: Callable[[], Any],
+    fn_fingerprint: str,
+    drop_last: bool,
+) -> Callable[[Iterable[object]], Iterator[object]]:
+    """Return a stage that runs the assembler and attaches ``__cache_meta__``.
+
+    Each output sample receives per-field signatures derived from the
+    aggregated input signatures, the assembler fingerprint, the output
+    index, and the field name.  The output is routed to the shard of the
+    last contributing input sample.
+
+    Args:
+        assembler_factory: Zero-argument callable that creates a fresh
+            :class:`~mvp_dataset.core.types.Assembler` instance.
+        fn_fingerprint: Stable hash of the factory callable.
+        drop_last: Whether to discard unfinished tail state on stream end.
+
+    Returns:
+        A stage callable ``(Iterable) -> Iterator`` that runs the
+        assembler and attaches ``__cache_meta__`` to each output.
+    """
+
+    def _stage(data: Iterable[object]) -> Iterator[object]:
+        assembler = assembler_factory()
+        accumulated_sigs: list[str] = []
+        last_route_shard: str = ""
+        output_index = 0
+
+        def _tag_output(output: object) -> object:
+            nonlocal output_index
+            if not isinstance(output, dict):
+                return output
+            agg_sig = hash_bytes(*accumulated_sigs) if accumulated_sigs else fn_fingerprint
+            field_sigs: dict[str, str] = {}
+            for field in output:
+                if not _is_meta_field(field):
+                    field_sigs[field] = hash_bytes(agg_sig, fn_fingerprint, str(output_index), field)
+            if "__key__" not in output:
+                output["__key__"] = hash_bytes(*accumulated_sigs, str(output_index))[:32]
+            output[_CACHE_META_KEY] = CacheMeta(
+                route_shard=last_route_shard,
+                field_sigs=field_sigs,
+            )
+            output_index += 1
+            return output
+
+        for sample in data:
+            if isinstance(sample, dict) and _CACHE_META_KEY in sample:
+                meta: CacheMeta = sample[_CACHE_META_KEY]
+                accumulated_sigs.extend(meta.field_sigs.values())
+                last_route_shard = meta.route_shard
+                clean = {k: v for k, v in sample.items() if k != _CACHE_META_KEY}
+                for out in assembler.push(clean):
+                    yield _tag_output(out)
+            else:
+                for out in assembler.push(sample):
+                    yield _tag_output(out)
+
+        for out in assembler.finish(drop_last=drop_last):
+            yield _tag_output(out)
+
+    return _stage
+
+
+# ---------------------------------------------------------------------------
+# Cache write path
+# ---------------------------------------------------------------------------
+
+
+def build_shard_cache(
+    shard_path: str,
+    samples: list[tuple[Sample, CacheMeta]],
+    groups_spec: tuple[tuple[str, ...], ...] | None,
+    plan_fingerprint: str,
+    show_progress: bool,
+) -> dict[str, str]:
+    """Write group tar files for *shard_path* and return ``{label: tar_path}``.
+
+    Uses an atomic temp→rename pattern so partial writes are never seen.
+    A per-shard exclusive lock prevents concurrent builds.
+
+    Args:
+        shard_path: Path to the original source shard.
+        samples: Pre-cache output samples with their cache metadata.
+        groups_spec: Field grouping forwarded to :func:`normalize_groups`.
+        plan_fingerprint: Plan fingerprint written into the manifest.
+        show_progress: Whether to print progress to ``stderr``.
+
+    Returns:
+        A ``{group_label: tar_path}`` mapping for the written group tars.
+    """
+    with _ShardLock(shard_path):
+        # Re-check under lock: another process may have built it while we waited.
+        existing = read_manifest(shard_path, plan_fingerprint)
+        if existing is not None:
+            if show_progress:
+                print(f"[cache] reusing {Path(shard_path).name}", file=sys.stderr)
+            return existing
+
+        if show_progress:
+            print(f"[cache] building {Path(shard_path).name}", file=sys.stderr)
+
+        cache_dir = _cache_dir(shard_path)
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        shard_stem = Path(shard_path).stem
+
+        if not samples:
+            _write_manifest(shard_path, plan_fingerprint, {})
+            return {}
+
+        first_sample = samples[0][0]
+        groups = normalize_groups(groups_spec, first_sample.keys())
+
+        group_tars: dict[str, str] = {}
+
+        for group_fields in groups:
+            label = _group_label(group_fields)
+
+            # Compute group signature from per-field content signatures.
+            sig_parts: list[str] = []
+            for s_dict, s_meta in samples:
+                key = str(s_dict.get("__key__", ""))
+                for field in group_fields:
+                    sig_parts.append(f"{key}:{field}:{s_meta.field_sigs.get(field, '')}")
+            group_sig = hash_bytes(*sig_parts)[:16]
+
+            final_name = f"{shard_stem}-{label}-{group_sig}.tar"
+            final_path = cache_dir / final_name
+
+            if not final_path.is_file():
+                _write_group_tar(final_path, samples, group_fields)
+
+            group_tars[label] = str(final_path)
+
+        _write_manifest(shard_path, plan_fingerprint, group_tars)
+
+        if show_progress:
+            print(
+                f"[cache] done {Path(shard_path).name} ({len(group_tars)} group(s), {len(samples)} sample(s))",
+                file=sys.stderr,
+            )
+
+        return group_tars
+
+
+def _write_group_tar(
+    final_path: Path,
+    samples: list[tuple[Sample, CacheMeta]],
+    group_fields: tuple[str, ...],
+) -> None:
+    """Write one group tar to a temp file, then atomically rename it.
+
+    Args:
+        final_path: Destination path for the group tar.
+        samples: Sample/meta pairs to write.
+        group_fields: Field names belonging to this group.
+    """
+    tmp_path = final_path.with_suffix(".tmp.tar")
+    try:
+        with tarfile.open(str(tmp_path), "w") as tf:
+            for s_dict, s_meta in samples:
+                key = str(s_dict.get("__key__", ""))
+
+                # Per-field codec map stored in the sample's meta member.
+                codec_map: dict[str, str] = {}
+
+                for field in group_fields:
+                    if field not in s_dict:
+                        continue
+                    data, codec_tag = encode_value(s_dict[field])
+                    codec_map[field] = codec_tag
+                    member_name = f"{key}.{field}"
+                    ti = tarfile.TarInfo(name=member_name)
+                    ti.size = len(data)
+                    tf.addfile(ti, io.BytesIO(data))
+
+                # Write per-sample meta member with codec + signature info.
+                meta_payload: dict[str, Any] = {
+                    field: {
+                        "codec": codec_map[field],
+                        "sig": s_meta.field_sigs.get(field, ""),
+                    }
+                    for field in group_fields
+                    if field in codec_map
+                }
+                meta_bytes = json.dumps(meta_payload, separators=(",", ":")).encode("utf-8")
+                meta_name = f"{key}{_CACHE_META_SUFFIX}"
+                mti = tarfile.TarInfo(name=meta_name)
+                mti.size = len(meta_bytes)
+                tf.addfile(mti, io.BytesIO(meta_bytes))
+
+        tmp_path.rename(final_path)
+    except Exception:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Cache read path
+# ---------------------------------------------------------------------------
+
+
+def iter_cache_tar(tar_path: str) -> Iterator[Sample]:
+    """Yield samples from a single cache group tar, restoring field values via codecs.
+
+    Args:
+        tar_path: Path to a cache group tar file.
+
+    Yields:
+        Sample dicts with ``__key__`` and decoded field values.
+    """
+    with tarfile.open(tar_path, "r") as tf:
+        members = {m.name: m for m in tf.getmembers() if m.isfile()}
+
+        # Collect ordered keys via meta members (preserves write order).
+        ordered_keys: list[str] = []
+        seen_keys: set[str] = set()
+        for name in members:
+            if name.endswith(_CACHE_META_SUFFIX):
+                key = name[: -len(_CACHE_META_SUFFIX)]
+                if key not in seen_keys:
+                    ordered_keys.append(key)
+                    seen_keys.add(key)
+
+        for key in ordered_keys:
+            meta_member = members.get(f"{key}{_CACHE_META_SUFFIX}")
+            if meta_member is None:
+                continue
+            extracted_meta = tf.extractfile(meta_member)
+            if extracted_meta is None:
+                continue
+            codec_map: dict[str, dict[str, str]] = json.loads(extracted_meta.read())
+
+            sample: Sample = {"__key__": key}
+            for field, info in codec_map.items():
+                data_member = members.get(f"{key}.{field}")
+                if data_member is None:
+                    continue
+                extracted = tf.extractfile(data_member)
+                if extracted is None:
+                    continue
+                sample[field] = decode_value(extracted.read(), info["codec"])
+
+            yield sample
+
+
+def iter_cache_shard(shard_path: str, plan_fingerprint: str) -> Iterator[Sample]:
+    """Yield merged samples from all group tars for one source shard.
+
+    Group tars are read in parallel (zipped by position) and their fields
+    are merged into a single sample dict per position.
+
+    Args:
+        shard_path: Path to the original source shard.
+        plan_fingerprint: Plan fingerprint used to locate the manifest.
+
+    Yields:
+        Complete sample dicts with fields from all groups merged.
+
+    Raises:
+        RuntimeError: If no valid manifest exists for *shard_path*.
+    """
+    manifest = read_manifest(shard_path, plan_fingerprint)
+    if manifest is None:
+        msg = f"[CacheReadError] no valid manifest for shard {shard_path!r} (plan={plan_fingerprint!r})"
+        raise RuntimeError(msg)
+
+    if not manifest:
+        return
+
+    tar_paths = sorted(manifest.values())
+    if len(tar_paths) == 1:
+        yield from iter_cache_tar(tar_paths[0])
+        return
+
+    # Multiple groups: merge per-position (all tars share the same key ordering).
+    for parts in itertools.zip_longest(*[iter_cache_tar(tp) for tp in tar_paths]):
+        merged: Sample = {}
+        key: str = ""
+        for part in parts:
+            if part is None:
+                continue
+            key = str(part.pop("__key__", key))
+            merged.update(part)
+        merged["__key__"] = key
+        yield merged
+
+
+# ---------------------------------------------------------------------------
+# Warm-up orchestration
+# ---------------------------------------------------------------------------
+
+
+def warmup_cache(
+    assigned_shards: list[str],
+    pre_cache_stream: Iterator[object],
+    groups_spec: tuple[tuple[str, ...], ...] | None,
+    plan_fingerprint: str,
+    show_progress: bool,
+    unsupported_stage_kinds: list[str],
+) -> None:
+    """Run the full pre-cache pipeline and materialise cache for each shard.
+
+    Consumes *pre_cache_stream* entirely, groups the output samples by
+    their ``route_shard``, then calls :func:`build_shard_cache` for each
+    assigned shard under an exclusive lock.
+
+    Args:
+        assigned_shards: Shard paths this worker is responsible for.
+        pre_cache_stream: Fully composed pre-cache iterator (source +
+            cache-aware stages) that yields dict samples with
+            ``__cache_meta__`` attached.
+        groups_spec: Field grouping forwarded to :func:`build_shard_cache`.
+        plan_fingerprint: Plan fingerprint forwarded to the manifest.
+        show_progress: Whether to print progress to ``stderr``.
+        unsupported_stage_kinds: Stage kinds that appear before the cache
+            boundary but are not tracked for invalidation.  A warning is
+            emitted when non-empty.
+    """
+    if unsupported_stage_kinds:
+        warnings.warn(
+            f"[CacheInvalidationWarning] The following stage type(s) appear before "
+            f".cache() but are not tracked for invalidation: "
+            f"{unsupported_stage_kinds!r}. "
+            f"They will affect the first cache build but changes to their logic "
+            f"will NOT trigger a cache rebuild. Stale cache may be reused silently.",
+            stacklevel=4,
+        )
+
+    # Collect all pre-cache outputs grouped by route_shard.
+    shard_samples: dict[str, list[tuple[Sample, CacheMeta]]] = {s: [] for s in assigned_shards}
+
+    n_shards = len(assigned_shards)
+    for i, shard in enumerate(assigned_shards, 1):
+        if show_progress:
+            print(f"[cache] waiting shard {i}/{n_shards}: {Path(shard).name}", file=sys.stderr)
+
+    for item in pre_cache_stream:
+        if not isinstance(item, dict):
+            msg = (
+                f"[CacheBoundaryError] cache() boundary requires dict samples; "
+                f"got {type(item).__name__!r}. "
+                f"Stages like batch() must not appear before cache()."
+            )
+            raise TypeError(msg)
+        meta: CacheMeta | None = item.pop(_CACHE_META_KEY, None)
+        if meta is None:
+            # Unsupported stage dropped the meta – route to first assigned shard.
+            route = assigned_shards[0] if assigned_shards else ""
+            meta = CacheMeta(route_shard=route, field_sigs={})
+        route_shard = meta.route_shard
+        if route_shard not in shard_samples:
+            # Assemble may produce output routed to a shard not in assigned_shards.
+            # Skip samples that belong to other slots' shards.
+            continue
+        shard_samples[route_shard].append((item, meta))
+
+    # Build cache per shard (locked).
+    for i, shard in enumerate(assigned_shards, 1):
+        samples = shard_samples.get(shard, [])
+        if show_progress:
+            print(f"[cache] building shard {i}/{n_shards}: {Path(shard).name}", file=sys.stderr)
+        build_shard_cache(shard, samples, groups_spec, plan_fingerprint, show_progress)

--- a/src/mvp_dataset/cache/materialize.py
+++ b/src/mvp_dataset/cache/materialize.py
@@ -841,3 +841,52 @@ def warmup_cache(
         if show_progress:
             print(f"[cache] building shard {i}/{n_shards}: {Path(shard).name}", file=sys.stderr)
         build_shard_cache(shard, samples, groups_spec, plan_fingerprint, show_progress)
+
+
+def wait_for_cache(
+    assigned_shards: list[str],
+    plan_fingerprint: str,
+    *,
+    show_progress: bool = False,
+    poll_interval: float = 0.5,
+    timeout: float = 3600.0,
+) -> None:
+    """Block until valid cache manifests exist for all *assigned_shards*.
+
+    Used by non-leader model-parallel ranks (e.g. TP co-members) that skip
+    the warm-up phase and wait for the leader to finish building the cache.
+
+    Args:
+        assigned_shards: Shard paths whose caches must be ready.
+        plan_fingerprint: Expected plan fingerprint to validate manifests.
+        show_progress: Whether to print waiting status to ``stderr``.
+        poll_interval: Seconds between manifest existence checks.
+        timeout: Maximum seconds to wait before raising ``TimeoutError``.
+
+    Raises:
+        TimeoutError: If the cache is not ready within *timeout* seconds.
+    """
+    import time
+
+    pending = set(assigned_shards)
+    if show_progress and pending:
+        print(f"[cache] waiting for leader to build {len(pending)} shard(s)…", file=sys.stderr)
+
+    deadline = time.monotonic() + timeout
+    while pending:
+        if time.monotonic() > deadline:
+            msg = (
+                f"[CacheWaitTimeout] timed out after {timeout}s waiting for "
+                f"cache leader to build {len(pending)} shard(s): "
+                f"{[Path(s).name for s in sorted(pending)]}"
+            )
+            raise TimeoutError(msg)
+        time.sleep(poll_interval)
+        still_pending = set()
+        for shard in pending:
+            if read_manifest(shard, plan_fingerprint) is None:
+                still_pending.add(shard)
+        pending = still_pending
+
+    if show_progress:
+        print("[cache] leader finished, proceeding with cached data", file=sys.stderr)

--- a/src/mvp_dataset/core/types.py
+++ b/src/mvp_dataset/core/types.py
@@ -155,6 +155,26 @@ class DataLoadMesh:
             size *= self.device_mesh.size(dim)
         return size
 
+    @property
+    def is_cache_leader(self) -> bool:
+        """Whether this rank should lead cache warm-up for its model-parallel group.
+
+        In a mesh with both data-parallel and model-parallel (e.g. TP)
+        dimensions, all ranks sharing the same ``dp_rank`` receive the same
+        shards.  Only one of them — the one whose local rank on every
+        non-DP dimension is 0 — should build the cache.  The others wait
+        and reuse the result.
+
+        Returns:
+            ``True`` if this rank is the designated cache builder for its
+            model-parallel co-members, ``False`` otherwise.
+        """
+        all_dims: tuple[str, ...] = getattr(self.device_mesh, "mesh_dim_names", ())
+        non_dp_dims = [d for d in all_dims if d not in self.dp_dims]
+        if not non_dp_dims:
+            return True
+        return all(self.device_mesh.get_local_rank(d) == 0 for d in non_dp_dims)
+
 
 def _normalize_dp_dims(dp_dims: str | Sequence[str]) -> tuple[str, ...]:
     """Normalize one-or-many DP mesh dimension names into a tuple."""
@@ -279,6 +299,21 @@ class RuntimeContext:
 
         dp_size = self.mesh.dp_size if self.mesh is not None else self.world_size
         return dp_size * self.num_workers
+
+    @property
+    def is_cache_leader(self) -> bool:
+        """Whether this rank should lead cache warm-up for its model-parallel group.
+
+        When no mesh is set every rank is its own leader.  With a mesh,
+        delegates to :attr:`DataLoadMesh.is_cache_leader`.
+
+        Returns:
+            ``True`` if this rank should build the cache, ``False`` if it
+            should wait for a co-member to do so.
+        """
+        if self.mesh is None:
+            return True
+        return self.mesh.is_cache_leader
 
     @property
     def sample_shuffle_seed(self) -> int:

--- a/src/mvp_dataset/core/types.py
+++ b/src/mvp_dataset/core/types.py
@@ -6,8 +6,8 @@ import importlib
 import os
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Protocol
 from dataclasses import replace as dataclass_replace
+from typing import Literal, Protocol
 
 # ---------------------------------------------------------------------------
 # Shared aliases
@@ -37,6 +37,58 @@ RefFieldSpec = tuple[str, PathLikeStr]
 Stage = Callable[[Iterable[object]], Iterable[object]]
 """One lazy transformation stage in the iterator pipeline."""
 
+CacheTracePolicy = Literal["traceable", "unsupported"]
+"""Whether a stage participates in cache invalidation."""
+
+StageKind = Literal["map", "shuffle", "batch", "assemble", "unbatch"]
+"""Recognized pipeline stage kinds."""
+
+
+@dataclass(frozen=True, slots=True)
+class StageSpec:
+    """Metadata wrapper around one pipeline stage.
+
+    Attributes:
+        kind: Symbolic stage name (``"map"``, ``"shuffle"``, ``"batch"``, etc.).
+        apply: Standard stage callable used during normal (non-cache) iteration.
+        fn_fingerprint: Stable hash of the user-provided callable, used to
+            detect when a stage's logic changes and the cache must be rebuilt.
+            Empty string for unsupported stages.
+        cache_trace_policy: Whether the stage participates in per-field
+            signature tracking and cache invalidation.
+        cache_stage: Optional cache-aware version of the stage that propagates
+            ``__cache_meta__`` through the sample stream.  ``None`` for
+            unsupported stages that use the regular ``apply`` callable during
+            warm-up.
+    """
+
+    kind: StageKind
+    apply: Stage
+    fn_fingerprint: str
+    cache_trace_policy: CacheTracePolicy
+    cache_stage: Stage | None
+
+
+@dataclass(frozen=True, slots=True)
+class CacheSpec:
+    """Cache boundary descriptor attached to a :class:`~mvp_dataset.Dataset`.
+
+    Attributes:
+        boundary_index: Number of pre-cache :class:`StageSpec` entries.
+        groups: Field grouping for cache tars.  ``None`` means all non-meta
+            fields go into a single tar.  Each inner tuple is one group; keys
+            not covered by any group are stored as singleton groups.
+        show_progress: Whether to print progress to stderr during warm-up.
+        plan_fingerprint: Stable hash of all traceable pre-cache stage
+            fingerprints combined with the groups spec.  Changes when any
+            traceable stage changes.
+    """
+
+    boundary_index: int
+    groups: tuple[tuple[str, ...], ...] | None
+    show_progress: bool
+    plan_fingerprint: str
+
 
 class Assembler[T, U](Protocol):
     """Stateful stream assembler that may emit outputs after consuming inputs."""
@@ -46,6 +98,8 @@ class Assembler[T, U](Protocol):
 
     def finish(self, *, drop_last: bool = False) -> Iterable[U]:
         """Flush remaining state at end of stream."""
+
+
 @dataclass(frozen=True, slots=True)
 class DataLoadMesh:
     """Data-parallel sub-mesh specification for shard assignment.

--- a/src/mvp_dataset/pipeline/dataset.py
+++ b/src/mvp_dataset/pipeline/dataset.py
@@ -7,16 +7,18 @@ import os
 import random
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass
+from dataclasses import replace as dataclass_replace
 from types import ModuleType
 from typing import Literal, cast
 
 from ..core.types import (
     Assembler,
+    CacheSpec,
     RefFieldSpec,
     RuntimeContext,
     ShardInput,
     SidecarSpec,
-    Stage,
+    StageSpec,
 )
 from ..sources import iter_jsonls, iter_tars
 from ..sources.jsonl import materialize_jsonl_shards
@@ -33,6 +35,8 @@ from .ops import (
 SourceKind = Literal["jsonl", "tars"]
 SourceStore = list[str]
 SourceShape = Literal["tar_paths", "jsonl_paths"]
+
+_UNSUPPORTED_CACHE_KINDS = frozenset({"shuffle", "batch", "unbatch"})
 
 
 def torch_iterabledataset_class(
@@ -71,10 +75,11 @@ class Dataset(torch_iterabledataset_class()):
 
     _source: SourceStore
     _source_shape: SourceShape
-    _stages: tuple[Stage, ...]
+    _stages: tuple[StageSpec, ...]
     _resample: bool
     _sidecar_specs: tuple[SidecarSpec, ...]
     _ref_fields: tuple[RefFieldSpec, ...]
+    _cache_spec: CacheSpec | None
 
     @classmethod
     def from_tars(
@@ -292,6 +297,7 @@ class Dataset(torch_iterabledataset_class()):
             _resample=resample,
             _sidecar_specs=(),
             _ref_fields=(),
+            _cache_spec=None,
         )
 
     def join(self, sidecars: Sequence[SidecarSpec]) -> Dataset:
@@ -313,16 +319,7 @@ class Dataset(torch_iterabledataset_class()):
         if self.source_kind != "tars":
             msg = "`join` currently supports only tar sources."
             raise ValueError(msg)
-        return Dataset(
-            _source=self._source,
-            _source_shape=self._source_shape,
-            _stages=self._stages,
-            context=self.context,
-            source_kind=self.source_kind,
-            _resample=self._resample,
-            _sidecar_specs=self._sidecar_specs + tuple(sidecars),
-            _ref_fields=self._ref_fields,
-        )
+        return dataclass_replace(self, _sidecar_specs=self._sidecar_specs + tuple(sidecars))
 
     def resolve_refs(self, ref_fields: Sequence[RefFieldSpec]) -> Dataset:
         """Resolve ``tar://`` URIs in selected JSONL fields during iteration.
@@ -342,38 +339,19 @@ class Dataset(torch_iterabledataset_class()):
         if self.source_kind != "jsonl":
             msg = "`resolve_refs` currently supports only jsonl sources."
             raise ValueError(msg)
-        return Dataset(
-            _source=self._source,
-            _source_shape=self._source_shape,
-            _stages=self._stages,
-            context=self.context,
-            source_kind=self.source_kind,
-            _resample=self._resample,
-            _sidecar_specs=self._sidecar_specs,
-            _ref_fields=self._ref_fields + tuple(ref_fields),
-        )
+        return dataclass_replace(self, _ref_fields=self._ref_fields + tuple(ref_fields))
 
-    def _append_stage(self, stage: Stage) -> Dataset:
+    def _append_stage(self, spec: StageSpec) -> Dataset:
         """Return a new dataset with one extra lazy stage.
 
         Args:
-            stage: Iterator transformation applied after source loading.
+            spec: Stage spec to append to the pipeline.
 
         Returns:
-            A dataset that shares the same source and context but appends
-            ``stage`` to the pipeline.
+            A new :class:`Dataset` sharing the same source and context.
         """
 
-        return Dataset(
-            _source=self._source,
-            _source_shape=self._source_shape,
-            _stages=self._stages + (stage,),
-            context=self.context,
-            source_kind=self.source_kind,
-            _resample=self._resample,
-            _sidecar_specs=self._sidecar_specs,
-            _ref_fields=self._ref_fields,
-        )
+        return dataclass_replace(self, _stages=self._stages + (spec,))
 
     def map(self, fn: Callable[[object], object]) -> Dataset:
         """Append a lazy map stage.
@@ -384,11 +362,22 @@ class Dataset(torch_iterabledataset_class()):
         Returns:
             A new dataset that applies ``fn`` lazily during iteration.
         """
+        from ..cache.fingerprint import callable_fingerprint
+        from ..cache.materialize import make_cache_aware_map
 
-        def stage(data: Iterable[object]) -> Iterable[object]:
+        fn_fp = callable_fingerprint(fn)
+
+        def _apply(data: Iterable[object]) -> Iterable[object]:
             return map_samples(data, fn)
 
-        return self._append_stage(stage)
+        spec = StageSpec(
+            kind="map",
+            apply=_apply,
+            fn_fingerprint=fn_fp,
+            cache_trace_policy="traceable",
+            cache_stage=make_cache_aware_map(fn, fn_fp),
+        )
+        return self._append_stage(spec)
 
     def shuffle(self, buffer_size: int, initial: int | None = None) -> Dataset:
         """Append a deterministic sample-level shuffle stage.
@@ -403,12 +392,19 @@ class Dataset(torch_iterabledataset_class()):
             A new dataset with bounded-memory shuffling applied lazily.
         """
 
-        def stage(data: Iterable[object]) -> Iterable[object]:
+        def _apply(data: Iterable[object]) -> Iterable[object]:
             seed = self.context.sample_shuffle_seed
             rng = random.Random(seed)
             return shuffle_samples(data, buffer_size=buffer_size, initial=initial, rng=rng)
 
-        return self._append_stage(stage)
+        spec = StageSpec(
+            kind="shuffle",
+            apply=_apply,
+            fn_fingerprint="",
+            cache_trace_policy="unsupported",
+            cache_stage=None,
+        )
+        return self._append_stage(spec)
 
     def batch(
         self,
@@ -428,7 +424,7 @@ class Dataset(torch_iterabledataset_class()):
             A new dataset that yields batches instead of individual samples.
         """
 
-        def stage(data: Iterable[object]) -> Iterable[object]:
+        def _apply(data: Iterable[object]) -> Iterable[object]:
             return batch_samples(
                 data,
                 batch_size=batch_size,
@@ -436,7 +432,14 @@ class Dataset(torch_iterabledataset_class()):
                 collate_fn=collate_fn,
             )
 
-        return self._append_stage(stage)
+        spec = StageSpec(
+            kind="batch",
+            apply=_apply,
+            fn_fingerprint="",
+            cache_trace_policy="unsupported",
+            cache_stage=None,
+        )
+        return self._append_stage(spec)
 
     def assemble(
         self,
@@ -456,15 +459,31 @@ class Dataset(torch_iterabledataset_class()):
         Returns:
             A new dataset that assembles the upstream sample stream lazily.
         """
+        from ..cache.fingerprint import callable_fingerprint
+        from ..cache.materialize import make_cache_aware_assemble
 
-        def stage(data: Iterable[object]) -> Iterable[object]:
+        fn_fp = callable_fingerprint(factory)
+        ctx = self.context
+
+        def _apply(data: Iterable[object]) -> Iterable[object]:
             return assemble_samples(
                 data,
-                factory=lambda: factory(self.context),
+                factory=lambda: factory(ctx),
                 drop_last=drop_last,
             )
 
-        return self._append_stage(stage)
+        spec = StageSpec(
+            kind="assemble",
+            apply=_apply,
+            fn_fingerprint=fn_fp,
+            cache_trace_policy="traceable",
+            cache_stage=make_cache_aware_assemble(
+                lambda: factory(ctx),
+                fn_fp,
+                drop_last,
+            ),
+        )
+        return self._append_stage(spec)
 
     def unbatch(self) -> Dataset:
         """Append an unbatching stage.
@@ -474,10 +493,70 @@ class Dataset(torch_iterabledataset_class()):
             into individual samples during iteration.
         """
 
-        def stage(data: Iterable[object]) -> Iterable[object]:
+        def _apply(data: Iterable[object]) -> Iterable[object]:
             return unbatch_samples(data)
 
-        return self._append_stage(stage)
+        spec = StageSpec(
+            kind="unbatch",
+            apply=_apply,
+            fn_fingerprint="",
+            cache_trace_policy="unsupported",
+            cache_stage=None,
+        )
+        return self._append_stage(spec)
+
+    def cache(
+        self,
+        groups: Sequence[Sequence[str]] | None = None,
+        *,
+        show_progress: bool = True,
+    ) -> Dataset:
+        """Insert a cache boundary after the current pipeline stages.
+
+        On the first :meth:`__iter__` call the pipeline up to this boundary is
+        materialized into tar files on disk.  Subsequent iterations read from
+        those cached tars, skipping all upstream computation.
+
+        Args:
+            groups: Optional field grouping.  Each inner sequence specifies a
+                set of fields that should be stored together in one tar.
+                ``None`` (default) places all non-metadata fields in a single
+                tar.  Fields not covered by any explicit group are stored as
+                singleton groups.
+            show_progress: Whether to print warm-up progress to ``stderr``.
+
+        Returns:
+            A new dataset with the cache boundary registered.
+
+        Raises:
+            ValueError: If a cache boundary has already been registered on this
+                dataset.
+        """
+        if self._cache_spec is not None:
+            msg = "[CacheError] only one .cache() boundary is allowed per dataset"
+            raise ValueError(msg)
+
+        from ..cache.fingerprint import hash_bytes
+
+        normalized_groups: tuple[tuple[str, ...], ...] | None
+        if groups is None:
+            normalized_groups = None
+        else:
+            normalized_groups = tuple(tuple(g) for g in groups)
+
+        # Build plan fingerprint from all traceable pre-cache stage fingerprints.
+        pre_stage_fps = [spec.fn_fingerprint for spec in self._stages if spec.cache_trace_policy == "traceable"]
+        groups_repr = repr(normalized_groups)
+        plan_fp = hash_bytes(*pre_stage_fps, groups_repr)
+
+        cache_spec = CacheSpec(
+            boundary_index=len(self._stages),
+            groups=normalized_groups,
+            show_progress=show_progress,
+            plan_fingerprint=plan_fp,
+        )
+
+        return dataclass_replace(self, _cache_spec=cache_spec)
 
     def __iter__(self) -> Iterator[object]:
         """Materialize and run the full lazy pipeline.
@@ -486,6 +565,10 @@ class Dataset(torch_iterabledataset_class()):
             An iterator over samples or batch objects produced by the dataset's
             source backend followed by all appended pipeline stages.
         """
+
+        if self._cache_spec is not None:
+            yield from self._iter_with_cache()
+            return
 
         context = self.context.resolve_current_process()
         stream: Iterable[object]
@@ -517,8 +600,99 @@ class Dataset(torch_iterabledataset_class()):
                 tar_cache_size=tar_cache_size,
             )
 
-        for stage in self._stages:
-            stream = stage(stream)
+        for spec in self._stages:
+            stream = spec.apply(stream)
+
+        yield from stream
+
+    def _iter_with_cache(self) -> Iterator[object]:
+        """Run the pipeline using the cache layer.
+
+        On cache miss, builds a signature-annotated source stream, runs
+        pre-cache stages through their cache-aware variants, and
+        materializes the results into per-shard group tars.  On cache hit,
+        reads directly from the cached tars.  In both cases, post-cache
+        stages are applied on the output before yielding.
+
+        Yields:
+            Samples or batch objects produced by reading cached tars
+            followed by all post-cache pipeline stages.
+        """
+        from ..cache.materialize import (
+            iter_cache_shard,
+            iter_jsonls_with_sigs,
+            iter_tars_with_sigs,
+            read_manifest,
+            warmup_cache,
+        )
+
+        cache_spec = self._cache_spec
+        assert cache_spec is not None
+
+        context = self.context.resolve_current_process()
+        tar_key_dot_level = int(os.environ.get("LOADER_TAR_KEY_DOT_LEVEL", 1))
+        tar_cache_size = int(os.environ.get("LOADER_JSONL_TAR_CACHE_SIZE", 8))
+
+        if self.source_kind == "tars":
+            all_shards = self._as_tar_source()
+        else:
+            all_shards = self._as_jsonl_source()
+
+        assigned_shards = list(iter_items(all_shards, context=context, resample=False))
+
+        pre_specs = self._stages[: cache_spec.boundary_index]
+        post_specs = self._stages[cache_spec.boundary_index :]
+
+        # Check whether all assigned shards already have valid caches.
+        all_cached = all(read_manifest(shard, cache_spec.plan_fingerprint) is not None for shard in assigned_shards)
+
+        if not all_cached:
+            # --- Warm-up: build the cache. ---
+            # Build source stream with signature annotation.
+            if self.source_kind == "tars":
+                shard_stream: Iterator[str] = iter(assigned_shards)
+                source_stream = iter_tars_with_sigs(
+                    shard_stream,
+                    key_dot_level=tar_key_dot_level,
+                    sidecars=self._sidecar_specs,
+                )
+            else:
+                shard_stream = iter(assigned_shards)
+                source_stream = iter_jsonls_with_sigs(
+                    shard_stream,
+                    ref_fields=self._ref_fields,
+                    key_dot_level=tar_key_dot_level,
+                    tar_cache_size=tar_cache_size,
+                )
+
+            # Apply pre-cache stages with cache-aware versions where available.
+            pre_stream: Iterable[object] = source_stream
+            unsupported_kinds: list[str] = []
+            for spec in pre_specs:
+                if spec.cache_stage is not None:
+                    pre_stream = spec.cache_stage(pre_stream)
+                else:
+                    if spec.kind in _UNSUPPORTED_CACHE_KINDS:
+                        unsupported_kinds.append(spec.kind)
+                    pre_stream = spec.apply(pre_stream)
+
+            warmup_cache(
+                assigned_shards=assigned_shards,
+                pre_cache_stream=iter(pre_stream),
+                groups_spec=cache_spec.groups,
+                plan_fingerprint=cache_spec.plan_fingerprint,
+                show_progress=cache_spec.show_progress,
+                unsupported_stage_kinds=unsupported_kinds,
+            )
+
+        # --- Serve path: read from cache tars. ---
+        def _cache_source() -> Iterator[object]:
+            for shard in assigned_shards:
+                yield from iter_cache_shard(shard, cache_spec.plan_fingerprint)
+
+        stream: Iterable[object] = _cache_source()
+        for spec in post_specs:
+            stream = spec.apply(stream)
 
         yield from stream
 

--- a/src/mvp_dataset/pipeline/dataset.py
+++ b/src/mvp_dataset/pipeline/dataset.py
@@ -623,6 +623,7 @@ class Dataset(torch_iterabledataset_class()):
             iter_jsonls_with_sigs,
             iter_tars_with_sigs,
             read_manifest,
+            wait_for_cache,
             warmup_cache,
         )
 
@@ -647,43 +648,52 @@ class Dataset(torch_iterabledataset_class()):
         all_cached = all(read_manifest(shard, cache_spec.plan_fingerprint) is not None for shard in assigned_shards)
 
         if not all_cached:
-            # --- Warm-up: build the cache. ---
-            # Build source stream with signature annotation.
-            if self.source_kind == "tars":
-                shard_stream: Iterator[str] = iter(assigned_shards)
-                source_stream = iter_tars_with_sigs(
-                    shard_stream,
-                    key_dot_level=tar_key_dot_level,
-                    sidecars=self._sidecar_specs,
+            if not context.is_cache_leader:
+                # Non-leader TP co-member: skip warm-up, wait for the leader
+                # to finish building the cache for our shared shards.
+                wait_for_cache(
+                    assigned_shards,
+                    cache_spec.plan_fingerprint,
+                    show_progress=cache_spec.show_progress,
                 )
             else:
-                shard_stream = iter(assigned_shards)
-                source_stream = iter_jsonls_with_sigs(
-                    shard_stream,
-                    ref_fields=self._ref_fields,
-                    key_dot_level=tar_key_dot_level,
-                    tar_cache_size=tar_cache_size,
-                )
-
-            # Apply pre-cache stages with cache-aware versions where available.
-            pre_stream: Iterable[object] = source_stream
-            unsupported_kinds: list[str] = []
-            for spec in pre_specs:
-                if spec.cache_stage is not None:
-                    pre_stream = spec.cache_stage(pre_stream)
+                # --- Warm-up: build the cache. ---
+                # Build source stream with signature annotation.
+                if self.source_kind == "tars":
+                    shard_stream: Iterator[str] = iter(assigned_shards)
+                    source_stream = iter_tars_with_sigs(
+                        shard_stream,
+                        key_dot_level=tar_key_dot_level,
+                        sidecars=self._sidecar_specs,
+                    )
                 else:
-                    if spec.kind in _UNSUPPORTED_CACHE_KINDS:
-                        unsupported_kinds.append(spec.kind)
-                    pre_stream = spec.apply(pre_stream)
+                    shard_stream = iter(assigned_shards)
+                    source_stream = iter_jsonls_with_sigs(
+                        shard_stream,
+                        ref_fields=self._ref_fields,
+                        key_dot_level=tar_key_dot_level,
+                        tar_cache_size=tar_cache_size,
+                    )
 
-            warmup_cache(
-                assigned_shards=assigned_shards,
-                pre_cache_stream=iter(pre_stream),
-                groups_spec=cache_spec.groups,
-                plan_fingerprint=cache_spec.plan_fingerprint,
-                show_progress=cache_spec.show_progress,
-                unsupported_stage_kinds=unsupported_kinds,
-            )
+                # Apply pre-cache stages with cache-aware versions where available.
+                pre_stream: Iterable[object] = source_stream
+                unsupported_kinds: list[str] = []
+                for spec in pre_specs:
+                    if spec.cache_stage is not None:
+                        pre_stream = spec.cache_stage(pre_stream)
+                    else:
+                        if spec.kind in _UNSUPPORTED_CACHE_KINDS:
+                            unsupported_kinds.append(spec.kind)
+                        pre_stream = spec.apply(pre_stream)
+
+                warmup_cache(
+                    assigned_shards=assigned_shards,
+                    pre_cache_stream=iter(pre_stream),
+                    groups_spec=cache_spec.groups,
+                    plan_fingerprint=cache_spec.plan_fingerprint,
+                    show_progress=cache_spec.show_progress,
+                    unsupported_stage_kinds=unsupported_kinds,
+                )
 
         # --- Serve path: read from cache tars. ---
         def _cache_source() -> Iterator[object]:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,527 @@
+"""Tests for Dataset.cache() – materialization, invalidation, and codecs."""
+
+from __future__ import annotations
+
+import io
+import json
+import tarfile
+import warnings
+from pathlib import Path
+
+import pytest
+
+from mvp_dataset import Dataset
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_tar(path: Path, samples: list[dict]) -> None:
+    """Write samples to a tar file using the ``{key}.{field}`` convention."""
+    with tarfile.open(str(path), "w") as tf:
+        for sample in samples:
+            key = sample["__key__"]
+            for field, value in sample.items():
+                if field.startswith("__") and field.endswith("__"):
+                    continue
+                if isinstance(value, bytes):
+                    data = value
+                elif isinstance(value, str):
+                    data = value.encode()
+                else:
+                    data = str(value).encode()
+                member_name = f"{key}.{field}"
+                ti = tarfile.TarInfo(name=member_name)
+                ti.size = len(data)
+                tf.addfile(ti, io.BytesIO(data))
+
+
+def _make_jsonl(path: Path, rows: list[dict]) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Basic cache build / reuse
+# ---------------------------------------------------------------------------
+
+
+def test_cache_build_and_reuse(tmp_path):
+    """First iteration builds cache; second iteration skips upstream map."""
+    shard = tmp_path / "shard-00000.tar"
+    _make_tar(
+        shard,
+        [
+            {"__key__": "0001", "image": b"img1", "label": b"lbl1"},
+            {"__key__": "0002", "image": b"img2", "label": b"lbl2"},
+        ],
+    )
+
+    call_count = [0]
+
+    def my_map(sample):
+        call_count[0] += 1
+        return {**sample, "processed": b"yes"}
+
+    ds = Dataset.from_tars([str(shard)]).map(my_map).cache(show_progress=False)
+
+    # First pass: warm-up builds cache.
+    samples1 = list(ds)
+    assert call_count[0] == 2
+
+    # Second pass: reads from cache; map should NOT be called again.
+    call_count[0] = 0
+    samples2 = list(ds)
+    assert call_count[0] == 0
+
+    assert len(samples1) == len(samples2) == 2
+    for s1, s2 in zip(samples1, samples2, strict=True):
+        assert s1["image"] == s2["image"]
+        assert s1["processed"] == s2["processed"]
+        assert s1["__key__"] == s2["__key__"]
+
+
+def test_cache_invalidation_on_fn_change(tmp_path):
+    """Changing the map function produces new cache files."""
+    shard = tmp_path / "shard-00000.tar"
+    _make_tar(shard, [{"__key__": "0001", "x": b"hello"}])
+
+    def fn_v1(sample):
+        return {**sample, "tag": b"v1"}
+
+    def fn_v2(sample):
+        return {**sample, "tag": b"v2"}
+
+    ds1 = Dataset.from_tars([str(shard)]).map(fn_v1).cache(show_progress=False)
+    ds2 = Dataset.from_tars([str(shard)]).map(fn_v2).cache(show_progress=False)
+
+    result1 = list(ds1)
+    result2 = list(ds2)
+
+    assert result1[0]["tag"] == b"v1"
+    assert result2[0]["tag"] == b"v2"
+
+    # Different plan fingerprints → different cache tar files coexist.
+    cache_tars = list((tmp_path / ".cache").glob("*.tar"))
+    assert len(cache_tars) == 2
+
+
+def test_cache_directory_layout(tmp_path):
+    """Cache tars are written under <shard_parent>/.cache/."""
+    shard = tmp_path / "shard-00000.tar"
+    _make_tar(shard, [{"__key__": "0001", "data": b"hello"}])
+
+    ds = Dataset.from_tars([str(shard)]).cache(show_progress=False)
+    list(ds)
+
+    cache_dir = tmp_path / ".cache"
+    assert cache_dir.is_dir()
+    assert (cache_dir / "shard-00000.tar.manifest.json").is_file()
+    group_tars = list(cache_dir.glob("shard-00000-*.tar"))
+    assert len(group_tars) == 1
+
+
+# ---------------------------------------------------------------------------
+# Groups
+# ---------------------------------------------------------------------------
+
+
+def test_cache_groups_explicit(tmp_path):
+    """Explicit groups split fields into separate tars; uncovered key → singleton."""
+    shard = tmp_path / "shard-00000.tar"
+    _make_tar(
+        shard,
+        [
+            {"__key__": "0001", "image": b"i1", "depth": b"d1", "label": b"l1"},
+        ],
+    )
+
+    ds = Dataset.from_tars([str(shard)]).cache(
+        groups=[["image", "depth"]],
+        show_progress=False,
+    )
+    samples = list(ds)
+
+    assert samples[0]["image"] == b"i1"
+    assert samples[0]["depth"] == b"d1"
+    assert samples[0]["label"] == b"l1"
+
+    # Two group tars: image+depth together, label as singleton.
+    cache_tars = sorted((tmp_path / ".cache").glob("*.tar"))
+    assert len(cache_tars) == 2
+
+
+def test_cache_groups_none_all_in_one(tmp_path):
+    """groups=None puts all non-meta fields in a single tar."""
+    shard = tmp_path / "shard-00000.tar"
+    _make_tar(shard, [{"__key__": "0001", "a": b"A", "b": b"B"}])
+
+    ds = Dataset.from_tars([str(shard)]).cache(show_progress=False)
+    list(ds)
+
+    cache_tars = list((tmp_path / ".cache").glob("*.tar"))
+    assert len(cache_tars) == 1
+
+
+# ---------------------------------------------------------------------------
+# Signature propagation through map
+# ---------------------------------------------------------------------------
+
+
+def test_map_signature_unchanged_field(tmp_path):
+    """Unchanged fields in map keep the same signature → same tar filename."""
+    shard = tmp_path / "shard-00000.tar"
+    _make_tar(shard, [{"__key__": "0001", "a": b"A", "b": b"B"}])
+
+    def map_only_b(sample):
+        # Only modify 'b'; 'a' is passed through unchanged.
+        return {**sample, "b": b"B_modified"}
+
+    ds = (
+        Dataset.from_tars([str(shard)])
+        .map(map_only_b)
+        .cache(
+            groups=[["a"], ["b"]],
+            show_progress=False,
+        )
+    )
+    list(ds)
+
+    cache_dir = tmp_path / ".cache"
+    tars = sorted(cache_dir.glob("*.tar"))
+    # Expect two group tars: one for 'a', one for 'b'.
+    assert len(tars) == 2
+
+
+def test_map_signature_changes_cause_new_tar(tmp_path):
+    """Modifying a field value and rebuilding cache produces a new tar filename."""
+    shard = tmp_path / "shard-00000.tar"
+    _make_tar(shard, [{"__key__": "0001", "x": b"val"}])
+
+    def fn_a(sample):
+        return {**sample, "x": b"result_a"}
+
+    def fn_b(sample):
+        return {**sample, "x": b"result_b"}
+
+    ds_a = Dataset.from_tars([str(shard)]).map(fn_a).cache(show_progress=False)
+    ds_b = Dataset.from_tars([str(shard)]).map(fn_b).cache(show_progress=False)
+
+    list(ds_a)
+    list(ds_b)
+
+    tars = list((tmp_path / ".cache").glob("*.tar"))
+    # Different sigs → two distinct tars.
+    assert len(tars) == 2
+
+
+# ---------------------------------------------------------------------------
+# Unsupported stage warning
+# ---------------------------------------------------------------------------
+
+
+def test_unsupported_stage_warning(tmp_path):
+    """shuffle() before cache() emits a CacheInvalidationWarning."""
+    shard = tmp_path / "shard-00000.tar"
+    _make_tar(shard, [{"__key__": "0001", "x": b"v"}])
+
+    ds = Dataset.from_tars([str(shard)]).shuffle(100).cache(show_progress=False)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        list(ds)
+
+    warning_texts = [str(w.message) for w in caught]
+    assert any("CacheInvalidationWarning" in t for t in warning_texts)
+    assert any("shuffle" in t for t in warning_texts)
+
+
+def test_unsupported_stage_cache_reuse(tmp_path):
+    """shuffle() before cache() still builds a cache that is reused."""
+    shard = tmp_path / "shard-00000.tar"
+    _make_tar(
+        shard,
+        [
+            {"__key__": "0001", "x": b"v1"},
+            {"__key__": "0002", "x": b"v2"},
+        ],
+    )
+
+    ds = Dataset.from_tars([str(shard)]).shuffle(100).cache(show_progress=False)
+
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        samples1 = list(ds)
+        # Second iteration: cache is hit (no rebuild).
+        samples2 = list(ds)
+
+    assert len(samples1) == 2
+    assert len(samples2) == 2
+
+
+# ---------------------------------------------------------------------------
+# Codec round-trip
+# ---------------------------------------------------------------------------
+
+
+def _roundtrip(value, tmp_path):
+    """Cache and recover a single field value."""
+    shard = tmp_path / "shard-00000.tar"
+    _make_tar(shard, [{"__key__": "k", "field": b"placeholder"}])
+
+    def inject(sample):
+        return {"__key__": sample["__key__"], "field": value}
+
+    ds = Dataset.from_tars([str(shard)]).map(inject).cache(show_progress=False)
+    # First pass builds cache, second pass reads it.
+    list(ds)
+    result = list(ds)
+    return result[0]["field"]
+
+
+def test_codec_bytes(tmp_path):
+    assert _roundtrip(b"hello bytes", tmp_path) == b"hello bytes"
+
+
+def test_codec_str(tmp_path):
+    assert _roundtrip("hello str", tmp_path) == "hello str"
+
+
+def test_codec_json_scalar(tmp_path):
+    assert _roundtrip(42, tmp_path) == 42
+
+
+def test_codec_json_list(tmp_path):
+    assert _roundtrip([1, 2, 3], tmp_path) == [1, 2, 3]
+
+
+def test_codec_json_dict(tmp_path):
+    assert _roundtrip({"a": 1, "b": "two"}, tmp_path) == {"a": 1, "b": "two"}
+
+
+def test_codec_none(tmp_path):
+    assert _roundtrip(None, tmp_path) is None
+
+
+def test_codec_numpy(tmp_path):
+    np = pytest.importorskip("numpy")
+
+    shard = tmp_path / "shard-00000.tar"
+    # Store raw bytes in tar; map converts to ndarray (no ndarray in closure).
+    _make_tar(shard, [{"__key__": "k", "field": b"\x00\x00\x80?\x00\x00\x00@"}])
+
+    def to_arr(sample):
+        arr = np.array([1.0, 2.0], dtype=np.float32)
+        return {"__key__": sample["__key__"], "field": arr}
+
+    ds = Dataset.from_tars([str(shard)]).map(to_arr).cache(show_progress=False)
+    list(ds)  # warm-up
+    result = list(ds)
+    assert isinstance(result[0]["field"], np.ndarray)
+    np.testing.assert_array_equal(result[0]["field"], np.array([1.0, 2.0], dtype=np.float32))
+
+
+def test_codec_torch(tmp_path):
+    torch = pytest.importorskip("torch")
+    np = pytest.importorskip("numpy")
+
+    shard = tmp_path / "shard-00000.tar"
+    _make_tar(shard, [{"__key__": "k", "field": b"placeholder"}])
+
+    def to_tensor(sample):
+        return {"__key__": sample["__key__"], "field": torch.tensor([1.0, 2.0, 3.0])}
+
+    ds = Dataset.from_tars([str(shard)]).map(to_tensor).cache(show_progress=False)
+    list(ds)  # warm-up
+    result = list(ds)
+    assert isinstance(result[0]["field"], torch.Tensor)
+    np.testing.assert_array_equal(result[0]["field"].numpy(), [1.0, 2.0, 3.0])
+
+
+def test_codec_unsupported_type(tmp_path):
+    """Encoding an unsupported type should raise TypeError."""
+    from mvp_dataset.cache.codecs import encode_value
+
+    with pytest.raises(TypeError, match="CacheCodecError"):
+        encode_value(object())
+
+
+# ---------------------------------------------------------------------------
+# JSONL source
+# ---------------------------------------------------------------------------
+
+
+def test_cache_jsonl_source(tmp_path):
+    """cache() works with a JSONL source."""
+    shard = tmp_path / "shard-00000.jsonl"
+    _make_jsonl(
+        shard,
+        [
+            {"__key__": "r0", "__file__": str(shard), "__index_in_file__": 0, "text": "hello"},
+            {"__key__": "r1", "__file__": str(shard), "__index_in_file__": 1, "text": "world"},
+        ],
+    )
+
+    call_count = [0]
+
+    def fn(sample):
+        call_count[0] += 1
+        return {**sample, "upper": sample["text"].upper()}
+
+    ds = Dataset.from_jsonl([str(shard)]).map(fn).cache(show_progress=False)
+
+    list(ds)
+    assert call_count[0] == 2
+
+    call_count[0] = 0
+    result = list(ds)
+    assert call_count[0] == 0
+    assert {s["upper"] for s in result} == {"HELLO", "WORLD"}
+
+
+# ---------------------------------------------------------------------------
+# Assemble round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_cache_assemble_roundtrip(tmp_path):
+    """Assembled outputs survive a cache round-trip."""
+    from mvp_dataset import RuntimeContext
+
+    shard = tmp_path / "shard-00000.tar"
+    _make_tar(
+        shard,
+        [
+            {"__key__": "0001", "x": b"a"},
+            {"__key__": "0002", "x": b"b"},
+            {"__key__": "0003", "x": b"c"},
+            {"__key__": "0004", "x": b"d"},
+        ],
+    )
+
+    class PairAssembler:
+        def __init__(self):
+            self._buf: list = []
+
+        def push(self, sample):
+            self._buf.append(sample)
+            if len(self._buf) == 2:
+                a, b_ = self._buf
+                self._buf = []
+                yield {"__key__": f"{a['__key__']}+{b_['__key__']}", "pair": a["x"] + b_["x"]}
+
+        def finish(self, *, drop_last=False):
+            if self._buf and not drop_last:
+                yield {"__key__": self._buf[0]["__key__"], "pair": self._buf[0]["x"]}
+            self._buf = []
+
+    def factory(_ctx: RuntimeContext) -> PairAssembler:
+        return PairAssembler()
+
+    ds = Dataset.from_tars([str(shard)]).assemble(factory).cache(show_progress=False)
+
+    results1 = list(ds)
+    results2 = list(ds)
+
+    assert len(results1) == len(results2) == 2
+    for r1, r2 in zip(results1, results2, strict=True):
+        assert r1["pair"] == r2["pair"]
+
+
+# ---------------------------------------------------------------------------
+# Multiple .cache() calls should raise
+# ---------------------------------------------------------------------------
+
+
+def test_double_cache_raises(tmp_path):
+    shard = tmp_path / "shard-00000.tar"
+    _make_tar(shard, [{"__key__": "0001", "x": b"v"}])
+
+    with pytest.raises(ValueError, match="only one .cache()"):
+        Dataset.from_tars([str(shard)]).cache().cache()
+
+
+# ---------------------------------------------------------------------------
+# Post-cache stages execute after serving
+# ---------------------------------------------------------------------------
+
+
+def test_post_cache_map(tmp_path):
+    """Map stages placed after .cache() run on cached data."""
+    shard = tmp_path / "shard-00000.tar"
+    _make_tar(shard, [{"__key__": "0001", "x": b"hello"}])
+
+    post_call = [0]
+
+    def post_fn(sample):
+        post_call[0] += 1
+        return {**sample, "y": b"post"}
+
+    ds = Dataset.from_tars([str(shard)]).cache(show_progress=False).map(post_fn)
+
+    list(ds)
+    assert post_call[0] == 1
+
+    post_call[0] = 0
+    result = list(ds)
+    assert post_call[0] == 1  # runs every iteration
+    assert result[0]["y"] == b"post"
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint utilities
+# ---------------------------------------------------------------------------
+
+
+def test_callable_fingerprint_stable():
+    from mvp_dataset.cache.fingerprint import callable_fingerprint
+
+    def fn(x):
+        return x + 1
+
+    fp1 = callable_fingerprint(fn)
+    fp2 = callable_fingerprint(fn)
+    assert fp1 == fp2
+    assert len(fp1) == 64  # SHA-256 hex
+
+
+def test_callable_fingerprint_differs_on_body_change():
+    from mvp_dataset.cache.fingerprint import callable_fingerprint
+
+    def fn_a(x):
+        return x + 1
+
+    def fn_b(x):
+        return x + 2
+
+    assert callable_fingerprint(fn_a) != callable_fingerprint(fn_b)
+
+
+def test_callable_fingerprint_closure():
+    from mvp_dataset.cache.fingerprint import callable_fingerprint
+
+    def make(v):
+        def fn(x):
+            return x + v
+
+        return fn
+
+    assert callable_fingerprint(make(1)) != callable_fingerprint(make(2))
+    assert callable_fingerprint(make(1)) == callable_fingerprint(make(1))
+
+
+def test_callable_fingerprint_unsupported_closure():
+    from mvp_dataset.cache.fingerprint import callable_fingerprint
+
+    class Opaque:
+        pass
+
+    obj = Opaque()
+
+    def fn(x):
+        return obj
+
+    with pytest.raises(ValueError, match="CacheFingerprintError"):
+        callable_fingerprint(fn)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -525,3 +525,210 @@ def test_callable_fingerprint_unsupported_closure():
 
     with pytest.raises(ValueError, match="CacheFingerprintError"):
         callable_fingerprint(fn)
+
+
+# ---------------------------------------------------------------------------
+# DataLoadMesh / RuntimeContext – is_cache_leader
+# ---------------------------------------------------------------------------
+
+
+class _FakeMesh:
+    """Minimal stand-in for ``torch.distributed.DeviceMesh``."""
+
+    def __init__(self, dim_names: tuple[str, ...], local_ranks: dict[str, int], sizes: dict[str, int]):
+        self.mesh_dim_names = dim_names
+        self._local_ranks = local_ranks
+        self._sizes = sizes
+
+    def get_local_rank(self, dim: str) -> int:
+        return self._local_ranks[dim]
+
+    def size(self, dim: str) -> int:
+        return self._sizes[dim]
+
+
+def test_is_cache_leader_no_mesh():
+    """Without a mesh every rank is its own leader."""
+    from mvp_dataset.core.types import RuntimeContext
+
+    ctx = RuntimeContext(rank=3, world_size=4)
+    assert ctx.is_cache_leader is True
+
+
+def test_is_cache_leader_pure_dp():
+    """When all mesh dims are DP, every rank is a leader (no TP dims)."""
+    from mvp_dataset.core.types import DataLoadMesh
+
+    mesh = _FakeMesh(
+        dim_names=("replicate", "shard"),
+        local_ranks={"replicate": 1, "shard": 0},
+        sizes={"replicate": 2, "shard": 4},
+    )
+    dlm = DataLoadMesh(device_mesh=mesh, dp_dims=("replicate", "shard"))
+    assert dlm.is_cache_leader is True
+
+
+def test_is_cache_leader_tp_leader():
+    """TP local-rank 0 is the leader."""
+    from mvp_dataset.core.types import DataLoadMesh, RuntimeContext
+
+    mesh = _FakeMesh(
+        dim_names=("dp", "tp"),
+        local_ranks={"dp": 1, "tp": 0},
+        sizes={"dp": 4, "tp": 2},
+    )
+    dlm = DataLoadMesh(device_mesh=mesh, dp_dims=("dp",))
+    assert dlm.is_cache_leader is True
+
+    ctx = RuntimeContext(rank=2, world_size=8, mesh=dlm)
+    assert ctx.is_cache_leader is True
+
+
+def test_is_cache_leader_tp_follower():
+    """TP local-rank != 0 is a follower and must NOT build cache."""
+    from mvp_dataset.core.types import DataLoadMesh, RuntimeContext
+
+    mesh = _FakeMesh(
+        dim_names=("dp", "tp"),
+        local_ranks={"dp": 1, "tp": 1},
+        sizes={"dp": 4, "tp": 2},
+    )
+    dlm = DataLoadMesh(device_mesh=mesh, dp_dims=("dp",))
+    assert dlm.is_cache_leader is False
+
+    ctx = RuntimeContext(rank=3, world_size=8, mesh=dlm)
+    assert ctx.is_cache_leader is False
+
+
+def test_is_cache_leader_3d_mesh():
+    """3-D mesh (replicate, shard, tensor): leader only when tensor local-rank == 0."""
+    from mvp_dataset.core.types import DataLoadMesh
+
+    # Leader: tensor=0
+    mesh_leader = _FakeMesh(
+        dim_names=("replicate", "shard", "tensor"),
+        local_ranks={"replicate": 0, "shard": 1, "tensor": 0},
+        sizes={"replicate": 2, "shard": 4, "tensor": 8},
+    )
+    assert DataLoadMesh(device_mesh=mesh_leader, dp_dims=("replicate", "shard")).is_cache_leader is True
+
+    # Follower: tensor=3
+    mesh_follower = _FakeMesh(
+        dim_names=("replicate", "shard", "tensor"),
+        local_ranks={"replicate": 0, "shard": 1, "tensor": 3},
+        sizes={"replicate": 2, "shard": 4, "tensor": 8},
+    )
+    assert DataLoadMesh(device_mesh=mesh_follower, dp_dims=("replicate", "shard")).is_cache_leader is False
+
+
+# ---------------------------------------------------------------------------
+# wait_for_cache
+# ---------------------------------------------------------------------------
+
+
+def test_wait_for_cache_immediate(tmp_path):
+    """wait_for_cache returns immediately when manifests already exist."""
+    from mvp_dataset.cache.materialize import _write_manifest, wait_for_cache
+
+    shard = str(tmp_path / "shard-00000.tar")
+    Path(shard).touch()
+    _write_manifest(shard, "fp123", {"g": str(tmp_path / "g.tar")})
+    Path(tmp_path / "g.tar").touch()
+
+    # Should return instantly without timeout.
+    wait_for_cache([shard], "fp123", poll_interval=0.01, timeout=1.0)
+
+
+def test_wait_for_cache_timeout(tmp_path):
+    """wait_for_cache raises TimeoutError when manifest never appears."""
+    from mvp_dataset.cache.materialize import wait_for_cache
+
+    shard = str(tmp_path / "shard-00000.tar")
+    Path(shard).touch()
+
+    with pytest.raises(TimeoutError, match="CacheWaitTimeout"):
+        wait_for_cache([shard], "fp_missing", poll_interval=0.01, timeout=0.05)
+
+
+def test_wait_for_cache_delayed(tmp_path):
+    """wait_for_cache succeeds when manifest appears after a short delay."""
+    import threading
+
+    from mvp_dataset.cache.materialize import _write_manifest, wait_for_cache
+
+    shard = str(tmp_path / "shard-00000.tar")
+    Path(shard).touch()
+    group_tar = tmp_path / "g.tar"
+    group_tar.touch()
+
+    def _build_later():
+        import time
+
+        time.sleep(0.1)
+        _write_manifest(shard, "fp_delayed", {"g": str(group_tar)})
+
+    t = threading.Thread(target=_build_later)
+    t.start()
+    wait_for_cache([shard], "fp_delayed", poll_interval=0.02, timeout=5.0)
+    t.join()
+
+
+# ---------------------------------------------------------------------------
+# Non-leader TP rank skips warm-up (end-to-end)
+# ---------------------------------------------------------------------------
+
+
+def test_non_leader_skips_warmup(tmp_path):
+    """A non-leader TP rank should read from cache built by the leader, not re-run the pipeline."""
+    from mvp_dataset.core.types import DataLoadMesh, RuntimeContext
+
+    # Create a shard.
+    shard = tmp_path / "shard-00000.tar"
+    _make_tar(
+        shard,
+        [
+            {"__key__": "a", "x": b"hello"},
+            {"__key__": "b", "x": b"world"},
+        ],
+    )
+
+    call_count = [0]
+
+    def counting_map(sample):
+        call_count[0] += 1
+        return {**sample, "y": b"mapped"}
+
+    # --- Leader (tp=0) builds the cache ---
+    leader_mesh = _FakeMesh(
+        dim_names=("dp", "tp"),
+        local_ranks={"dp": 0, "tp": 0},
+        sizes={"dp": 1, "tp": 2},
+    )
+    leader_ctx = RuntimeContext(
+        rank=0,
+        world_size=2,
+        mesh=DataLoadMesh(device_mesh=leader_mesh, dp_dims=("dp",)),
+    )
+    ds_leader = Dataset.from_tars([str(shard)], context=leader_ctx).map(counting_map).cache(show_progress=False)
+    leader_result = list(ds_leader)
+    assert call_count[0] == 2  # map ran for both samples
+    assert len(leader_result) == 2
+
+    # --- Follower (tp=1) should NOT run the map ---
+    call_count[0] = 0
+    follower_mesh = _FakeMesh(
+        dim_names=("dp", "tp"),
+        local_ranks={"dp": 0, "tp": 1},
+        sizes={"dp": 1, "tp": 2},
+    )
+    follower_ctx = RuntimeContext(
+        rank=1,
+        world_size=2,
+        mesh=DataLoadMesh(device_mesh=follower_mesh, dp_dims=("dp",)),
+    )
+    ds_follower = Dataset.from_tars([str(shard)], context=follower_ctx).map(counting_map).cache(show_progress=False)
+    follower_result = list(ds_follower)
+    assert call_count[0] == 0, "non-leader should NOT have run the map function"
+    assert len(follower_result) == 2
+    for s in follower_result:
+        assert s["y"] == b"mapped"


### PR DESCRIPTION
#2
Implement a caching layer that materializes pre-cache pipeline stages into tar files on disk, enabling expensive preprocessing to be computed once and reused across iterations. Features include:

- Per-field content-addressable signatures for fine-grained invalidation
- Atomic tar writes with flock-based concurrency safety
- Field grouping support for selective I/O
- Codec matrix (bytes/str/JSON/npy/npy_tensor) for round-trip fidelity
- Cache-aware map and assemble stage wrappers
- Plan fingerprint for automatic invalidation on pipeline changes