### PR TITLE
[WIP] feat: resume

### DIFF
--- a/src/mvp_dataset/core/dataset.py
+++ b/src/mvp_dataset/core/dataset.py
@@ -8,6 +8,7 @@ from dataclasses import replace as dataclass_replace
 
 from ..utils.sharding import assign_items
 from .context import RuntimeContext
+from .resume import RESUME_TOKEN_KEY, make_resume_state, validate_resume_state
 from .stages import (
     _AssembleStage,
     _BatchStage,
@@ -37,13 +38,67 @@ class Dataset(torch_iterabledataset_class()):
     _stages: tuple[StageSpec, ...]
     _resample: bool
     _iter_source_stream: Callable
+    _resume_state: dict[str, object] | None = None
+    _last_resume_token: object | None = None
+    _resume_step: int = 0
 
     def _build_source_stream(self, *, context: RuntimeContext) -> Iterable[object]:
         source_shard_stream = assign_items(self._source, context=context, resample=self._resample)
-        return self._iter_source_stream(source_shard_stream)
+        resume_cursor = self._resume_state.get("source_cursor") if self._resume_state is not None else None
+        return self._iter_source_stream(source_shard_stream, resume_cursor=resume_cursor)
 
     def _append_stage(self, spec: StageSpec) -> Dataset:
         return dataclass_replace(self, _stages=self._stages + (spec,))
+
+    def _resume_source_payload(self) -> dict[str, object]:
+        return {
+            "source": self._source,
+            "resample": self._resample,
+            "reader": self._iter_source_stream,
+        }
+
+    def _validate_resume_supported(self) -> None:
+        return None
+
+    def _track_source_resume(self, stream: Iterable[object]) -> Iterator[object]:
+        for sample in stream:
+            if isinstance(sample, dict) and RESUME_TOKEN_KEY in sample:
+                object.__setattr__(self, "_last_resume_token", sample[RESUME_TOKEN_KEY])
+            yield sample
+
+    def state_dict(self) -> dict[str, object]:
+        """Return a checkpointable state for the next dataset item."""
+
+        self._validate_resume_supported()
+        context = RuntimeContext.from_runtime(base=self.context)
+        source_cursor = self._last_resume_token
+        if source_cursor is None and self._resume_state is not None:
+            source_cursor = self._resume_state.get("source_cursor")
+        return make_resume_state(
+            source_kind=self._source_kind,
+            source=self._resume_source_payload(),
+            stages=self._stages,
+            context=context,
+            source_cursor=source_cursor,
+            step=self._resume_step,
+        )
+
+    def load_state_dict(self, state: dict[str, object]) -> Dataset:
+        """Load a previously returned dataset resume state."""
+
+        self._validate_resume_supported()
+        context = RuntimeContext.from_runtime(base=self.context)
+        validate_resume_state(
+            state,
+            source_kind=self._source_kind,
+            source=self._resume_source_payload(),
+            stages=self._stages,
+            context=context,
+        )
+        object.__setattr__(self, "_resume_state", dict(state))
+        object.__setattr__(self, "_last_resume_token", state.get("source_cursor"))
+        object.__setattr__(self, "_resume_step", int(state.get("step", 0)))
+        return self
 
     def map(self, fn: Callable[[object], object]) -> Dataset:
         """Append a lazy map stage.
@@ -162,10 +217,12 @@ class Dataset(torch_iterabledataset_class()):
     def __iter__(self) -> Iterator[object]:
         """Materialize and run the full lazy pipeline."""
         context = RuntimeContext.from_runtime(base=self.context)
-        stream: Iterable[object] = self._build_source_stream(context=context)
+        stream: Iterable[object] = self._track_source_resume(self._build_source_stream(context=context))
         for spec in self._stages:
             stream = spec.apply(stream)
-        yield from stream
+        for sample in stream:
+            object.__setattr__(self, "_resume_step", self._resume_step + 1)
+            yield sample
 
     @classmethod
     def from_source(cls, source_kind: SourceKind, *args, **kwargs) -> Dataset:

--- a/src/mvp_dataset/core/resume.py
+++ b/src/mvp_dataset/core/resume.py
@@ -1,0 +1,144 @@
+"""Small helpers for resumable dataset iteration."""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+
+from .context import RuntimeContext
+from .types import SourceKind, StageSpec
+
+RESUME_STATE_VERSION = 1
+RESUME_TOKEN_KEY = "__resume_token__"
+SUPPORTED_RESUME_STAGES = {"map", "select", "batch"}
+
+
+def runtime_fingerprint(context: RuntimeContext) -> dict[str, object]:
+    """Return the runtime values that must match for safe resume."""
+
+    mesh = context.mesh
+    mesh_payload = None if mesh is None else {"dp_rank": mesh.dp_rank, "dp_size": mesh.dp_size}
+    return {
+        "rank": context.rank,
+        "world_size": context.world_size,
+        "local_rank": context.local_rank,
+        "local_world_size": context.local_world_size,
+        "node_rank": context.node_rank,
+        "num_nodes": context.num_nodes,
+        "worker_id": context.worker_id,
+        "num_workers": context.num_workers,
+        "epoch": context.epoch,
+        "seed": context.seed,
+        "mesh": mesh_payload,
+    }
+
+
+def _path_payload(path: str) -> dict[str, object] | None:
+    try:
+        stat = Path(path).stat()
+    except OSError:
+        return None
+    return {
+        "path": path,
+        "is_dir": Path(path).is_dir(),
+        "mtime_ns": stat.st_mtime_ns,
+        "size": stat.st_size,
+    }
+
+
+def _normalize(value: object) -> object:
+    if dataclasses.is_dataclass(value):
+        return _normalize(dataclasses.asdict(value))
+    if isinstance(value, Mapping):
+        return {
+            str(key): _normalize(val)
+            for key, val in sorted(value.items(), key=lambda item: str(item[0]))
+            if key not in {"handle", "index_handle"}
+        }
+    if isinstance(value, (list, tuple)):
+        return [_normalize(item) for item in value]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        payload = _path_payload(value) if isinstance(value, str) else None
+        return {"path_stat": payload} if payload is not None else value
+    return repr(value)
+
+
+def source_fingerprint(source: object) -> str:
+    payload = _normalize(source)
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _stage_payload(spec: StageSpec) -> dict[str, object]:
+    if spec.kind not in SUPPORTED_RESUME_STAGES:
+        msg = (
+            f"[UnsupportedResumeStage] stage={spec.kind!r} is not resumable in this implementation; "
+            "supported stages are map, select, and batch"
+        )
+        raise ValueError(msg)
+    return {"kind": spec.kind, "apply": _normalize(spec.apply)}
+
+
+def pipeline_fingerprint(stages: Iterable[StageSpec]) -> str:
+    payload = [_stage_payload(spec) for spec in stages]
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def make_resume_state(
+    *,
+    source_kind: SourceKind,
+    source: object,
+    stages: Iterable[StageSpec],
+    context: RuntimeContext,
+    source_cursor: object,
+    step: int,
+) -> dict[str, object]:
+    return {
+        "version": RESUME_STATE_VERSION,
+        "step": step,
+        "source_kind": source_kind,
+        "runtime_fingerprint": runtime_fingerprint(context),
+        "source_fingerprint": source_fingerprint(source),
+        "pipeline_fingerprint": pipeline_fingerprint(stages),
+        "source_cursor": source_cursor,
+    }
+
+
+def validate_resume_state(
+    state: Mapping[str, object],
+    *,
+    source_kind: SourceKind,
+    source: object,
+    stages: Iterable[StageSpec],
+    context: RuntimeContext,
+) -> None:
+    if state.get("version") != RESUME_STATE_VERSION:
+        msg = f"[InvalidResumeState] unsupported version={state.get('version')!r}"
+        raise ValueError(msg)
+    expected = make_resume_state(
+        source_kind=source_kind,
+        source=source,
+        stages=stages,
+        context=context,
+        source_cursor=state.get("source_cursor"),
+        step=int(state.get("step", 0)),
+    )
+    for key in ("source_kind", "runtime_fingerprint", "source_fingerprint", "pipeline_fingerprint"):
+        if state.get(key) != expected[key]:
+            msg = f"[InvalidResumeState] {key} does not match current dataset"
+            raise ValueError(msg)
+
+
+def token_matches(token: object, cursor: object) -> bool:
+    return isinstance(token, Mapping) and isinstance(cursor, Mapping) and dict(token) == dict(cursor)
+
+
+def token_kind(cursor: object) -> str | None:
+    if isinstance(cursor, Mapping):
+        kind = cursor.get("kind")
+        return kind if isinstance(kind, str) else None
+    return None

--- a/src/mvp_dataset/loader/torch_loader.py
+++ b/src/mvp_dataset/loader/torch_loader.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import json
 import random
 from collections.abc import Callable, Iterable, Iterator
 from typing import Any
@@ -134,6 +135,7 @@ class TorchLoader:
         collate_fn: Callable[[list[object]], object] | None = None,
         drop_last: bool = False,
         _stages: tuple[LoaderStage, ...] | None = None,
+        resume_state: dict[str, object] | None = None,
         **loader_kwargs: Any,
     ) -> None:
         """Initialize a PyTorch-backed loader wrapper.
@@ -181,6 +183,9 @@ class TorchLoader:
         self._drop_last = drop_last
         self._loader_kwargs: dict[str, object] = dict(loader_kwargs)
         self._stages = tuple() if _stages is None else _stages
+        self._resume_step = 0
+        if resume_state is not None:
+            self.load_state_dict(resume_state)
 
     def _append_stage(self, stage: LoaderStage) -> TorchLoader:
         """Return a new loader with one additional post-merge stage.
@@ -204,8 +209,65 @@ class TorchLoader:
             collate_fn=self._collate_fn,
             drop_last=self._drop_last,
             _stages=self._stages + (stage,),
+            resume_state=self.state_dict() if self._resume_step else None,
             **self._loader_kwargs,
         )
+
+    def _loader_fingerprint(self) -> str:
+        payload = {
+            "num_workers": self._num_workers,
+            "batch_size": self._batch_size,
+            "pin_memory": self._pin_memory,
+            "persistent_workers": self._persistent_workers,
+            "prefetch_factor": self._prefetch_factor,
+            "multiprocessing_context": self._multiprocessing_context,
+            "drop_last": self._drop_last,
+            "collate_fn": repr(self._collate_fn),
+            "loader_kwargs": self._loader_kwargs,
+            "stages": [stage.__class__.__name__ for stage in self._stages],
+        }
+        return json.dumps(payload, sort_keys=True, default=repr)
+
+    def state_dict(self) -> dict[str, object]:
+        """Return a checkpointable loader state for the next yielded batch."""
+
+        if self._num_workers != 0:
+            msg = "[UnsupportedResume] TorchLoader resume currently supports num_workers=0"
+            raise ValueError(msg)
+        if self._stages:
+            msg = "[UnsupportedResume] loader-side stages are not resumable in this implementation"
+            raise ValueError(msg)
+        dataset_state_dict = getattr(self._dataset, "state_dict", None)
+        if not callable(dataset_state_dict):
+            msg = "[UnsupportedResume] upstream dataset does not expose state_dict()"
+            raise ValueError(msg)
+        return {
+            "version": 1,
+            "step": self._resume_step,
+            "loader_fingerprint": self._loader_fingerprint(),
+            "dataset": dataset_state_dict(),
+        }
+
+    def load_state_dict(self, state: dict[str, object]) -> TorchLoader:
+        """Load a state returned by :meth:`state_dict`."""
+
+        if state.get("version") != 1:
+            msg = f"[InvalidResumeState] unsupported loader state version={state.get('version')!r}"
+            raise ValueError(msg)
+        if state.get("loader_fingerprint") != self._loader_fingerprint():
+            msg = "[InvalidResumeState] loader settings do not match current TorchLoader"
+            raise ValueError(msg)
+        dataset_state = state.get("dataset")
+        if not isinstance(dataset_state, dict):
+            msg = "[InvalidResumeState] loader state is missing dataset state"
+            raise ValueError(msg)
+        dataset_load_state_dict = getattr(self._dataset, "load_state_dict", None)
+        if not callable(dataset_load_state_dict):
+            msg = "[UnsupportedResume] upstream dataset does not expose load_state_dict()"
+            raise ValueError(msg)
+        dataset_load_state_dict(dataset_state)
+        self._resume_step = int(state.get("step", 0))
+        return self
 
     def _build_torch_dataloader(self) -> Iterable[object]:
         """Build the underlying ``torch.utils.data.DataLoader`` instance.
@@ -349,4 +411,6 @@ class TorchLoader:
         stream: Iterable[object] = self._build_torch_dataloader()
         for stage in self._stages:
             stream = stage(stream)
-        yield from stream
+        for item in stream:
+            self._resume_step += 1
+            yield item

--- a/src/mvp_dataset/pipeline/ops.py
+++ b/src/mvp_dataset/pipeline/ops.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import random
 from collections.abc import Callable, Iterable, Iterator
 
+from ..core.resume import RESUME_TOKEN_KEY
 from ..core.types import Assembler
 
 
@@ -29,7 +30,7 @@ def select_samples(
         yield {
             key: value
             for key, value in sample.items()
-            if key in selected or (key.startswith("__") and key.endswith("__"))
+            if key in selected or (key != RESUME_TOKEN_KEY and key.startswith("__") and key.endswith("__"))
         }
 
 

--- a/src/mvp_dataset/sources/jsonl/dataset.py
+++ b/src/mvp_dataset/sources/jsonl/dataset.py
@@ -13,10 +13,11 @@ from .utils import iter_jsonls, split_jsonl_files
 class _JsonlSourceIter:
     ref_fields: tuple[RefFieldSpec, ...] = ()
 
-    def __call__(self, shard_stream):
+    def __call__(self, shard_stream, *, resume_cursor=None):
         return iter_jsonls(
             shard_stream,
             ref_fields=self.ref_fields,
+            resume_cursor=resume_cursor,
         )
 
 

--- a/src/mvp_dataset/sources/jsonl/utils.py
+++ b/src/mvp_dataset/sources/jsonl/utils.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from types import TracebackType
 
+from ...core.resume import RESUME_TOKEN_KEY, token_matches
 from ...core.types import PathLikeStr, RefFieldSpec, Sample
 
 _TAR_URI_PREFIX = "tar://"
@@ -357,10 +358,12 @@ def materialize_jsonl_shards(
 def iter_jsonls(
     shard_paths: Iterator[PathLikeStr],
     ref_fields: tuple[RefFieldSpec, ...],
+    resume_cursor: object | None = None,
 ) -> Iterator[Sample]:
     """Resolve tar data references while streaming JSONL shard files."""
     key_dot_level = int(os.environ.get("MVP_DATASET_TAR_KEY_DOT_LEVEL", "1"))
     max_open_tars = int(os.environ.get("MVP_DATASET_TAR_MAX_OPEN_FILES", "8"))
+    resume_seen = resume_cursor is None
 
     def _resolve_one(sample: Sample, manager: TarManager) -> Sample:
         resolved = dict(sample)
@@ -381,6 +384,16 @@ def iter_jsonls(
             with open(shard_path, encoding="utf-8") as handle:
                 for line_index, line in enumerate(handle):
                     sample = _parse_jsonl_line(str(shard_path), line_index, line, allow_preannotated=True)
+                    token = {
+                        "kind": "jsonl",
+                        "file": str(shard_path),
+                        "line_index": sample["__index_in_file__"],
+                        "key": sample["__key__"],
+                    }
+                    sample[RESUME_TOKEN_KEY] = token
+                    if not resume_seen:
+                        resume_seen = token_matches(token, resume_cursor)
+                        continue
                     yield _resolve_one(sample, manager)
 
 

--- a/src/mvp_dataset/sources/lance/dataset.py
+++ b/src/mvp_dataset/sources/lance/dataset.py
@@ -29,13 +29,14 @@ class _LanceSourceIter:
 
     handles_sharding = True
 
-    def __call__(self, source_stream):
+    def __call__(self, source_stream, *, resume_cursor=None):
         return iter_lance(
             self.source,
             source_stream,
             columns=self.columns,
             batch_size=self.batch_size,
             load_in_memory=self.load_in_memory,
+            resume_cursor=resume_cursor,
         )
 
 
@@ -115,8 +116,27 @@ class LanceDataset(Dataset):
             context=context,
             resample=self._resample,
             shuffle_mode=self._shuffle_mode,
+            resume_cursor=self._resume_state.get("source_cursor") if self._resume_state is not None else None,
         )
-        return self._iter_source_stream(source_shard_stream)
+        return self._iter_source_stream(source_shard_stream, resume_cursor=None)
+
+    def _resume_source_payload(self) -> dict[str, object]:
+        payload = Dataset._resume_source_payload(self)
+        payload["lance"] = {
+            "shuffle_mode": self._shuffle_mode,
+            "load_in_memory": self._load_in_memory,
+            "ref_index_scope": self._ref_index_scope,
+        }
+        return payload
+
+    def _validate_resume_supported(self) -> None:
+        Dataset._validate_resume_supported(self)
+        if self._shuffle_mode != "none":
+            msg = (
+                "[UnsupportedResumeSource] Lance resume currently supports only "
+                "shuffle_mode='none'; shuffle state is not checkpointed"
+            )
+            raise ValueError(msg)
 
     def resolve_ref(
         self,

--- a/src/mvp_dataset/sources/lance/utils/source.py
+++ b/src/mvp_dataset/sources/lance/utils/source.py
@@ -12,6 +12,7 @@ import pyarrow as pa
 import pyarrow.dataset as pads
 
 from mvp_dataset.core.context import RuntimeContext
+from mvp_dataset.core.resume import RESUME_TOKEN_KEY
 from mvp_dataset.core.types import PathLikeStr, Sample
 
 from .types import LanceDatasetSpec, LanceIndexItem, LanceShuffleMode, LanceSourceSpec
@@ -138,6 +139,7 @@ def assign_items(
     context: RuntimeContext,
     resample: bool,
     shuffle_mode: LanceShuffleMode = "none",
+    resume_cursor: object | None = None,
 ) -> Iterable[LanceIndexItem]:
     """Yield slot-assigned row indexes for a single logical Lance source.
 
@@ -178,6 +180,14 @@ def assign_items(
     slot = context.slot
     total_slots = context.total_slots
     global_index_list = np.arange(source_spec.total_rows)
+    start_global_index = 0
+    if (
+        shuffle_mode == "none"
+        and isinstance(resume_cursor, dict)
+        and resume_cursor.get("kind") == "lance"
+        and isinstance(resume_cursor.get("global_index"), int)
+    ):
+        start_global_index = int(resume_cursor["global_index"]) + 1
 
     while True:
         if shuffle_mode == "fragment_aware":
@@ -192,6 +202,8 @@ def assign_items(
                     source_spec.total_rows
                 )
             for i, global_index in enumerate(global_index_list):
+                if shuffle_mode == "none" and int(global_index) < start_global_index:
+                    continue
                 if i % total_slots != slot:
                     continue
 
@@ -213,6 +225,7 @@ def assign_items(
         if not resample:
             break
         round_index += 1
+        start_global_index = 0
 
 
 def _read_batch(
@@ -263,6 +276,12 @@ def _read_batch(
         sample["__local_index__"] = index_item.local_index
         sample["__global_index__"] = index_item.global_index
         sample["__key__"] = f"{dataset.uri}:{index_item.local_index}"
+        sample[RESUME_TOKEN_KEY] = {
+            "kind": "lance",
+            "dataset_i": index_item.dataset_i,
+            "local_index": index_item.local_index,
+            "global_index": index_item.global_index,
+        }
         batch.append(sample)
         per_dataset_offsets[index_item.dataset_i] += 1
 
@@ -276,6 +295,7 @@ def iter_lance(
     columns: Sequence[str] | None = None,
     batch_size: int = 1024,
     load_in_memory: bool = False,
+    resume_cursor: object | None = None,
 ):
     """Read Lance rows from an index stream and yield sample dictionaries.
 
@@ -318,6 +338,7 @@ def iter_lance(
             handle=ds_handle,
         )
 
+    _ = resume_cursor
     batch_indexes: list[LanceIndexItem] = []
     for index_item in index_stream:
         batch_indexes.append(index_item)

--- a/src/mvp_dataset/sources/parquet/dataset.py
+++ b/src/mvp_dataset/sources/parquet/dataset.py
@@ -14,11 +14,12 @@ class _ParquetSourceIter:
     columns: Sequence[str] | None = None
     use_threads: bool = True
 
-    def __call__(self, fragment_stream):
+    def __call__(self, fragment_stream, *, resume_cursor=None):
         return iter_parquets(
             fragment_stream,
             columns=self.columns,
             use_threads=self.use_threads,
+            resume_cursor=resume_cursor,
         )
 
 

--- a/src/mvp_dataset/sources/parquet/utils.py
+++ b/src/mvp_dataset/sources/parquet/utils.py
@@ -11,6 +11,7 @@ from typing import Final
 
 import pyarrow.parquet as pq
 
+from ...core.resume import RESUME_TOKEN_KEY
 from ...core.types import PathLikeStr, Sample
 
 _DEFAULT_BATCH_SIZE: Final[int] = 65536
@@ -147,6 +148,7 @@ def iter_parquet(
     columns: Sequence[str] | None = None,
     batch_size: int | None = None,
     use_threads: bool = True,
+    start_index: int | None = None,
 ) -> Iterator[Sample]:
     """Iterate one parquet row-group fragment and yield one sample dict per row."""
 
@@ -163,6 +165,9 @@ def iter_parquet(
         column_names = record_batch.schema.names
         columns_data = [record_batch.column(i) for i in range(record_batch.num_columns)]
         for batch_row_index in range(record_batch.num_rows):
+            if start_index is not None and index_in_file < start_index:
+                index_in_file += 1
+                continue
             sample: Sample = {
                 name: columns_data[column_index][batch_row_index].as_py()
                 for column_index, name in enumerate(column_names)
@@ -170,6 +175,13 @@ def iter_parquet(
             sample["__file__"] = fragment.path
             sample["__index_in_file__"] = index_in_file
             sample["__key__"] = f"{fragment.path}:{index_in_file}"
+            sample[RESUME_TOKEN_KEY] = {
+                "kind": "parquet",
+                "path": fragment.path,
+                "row_groups": list(fragment.row_groups),
+                "fragment_row_offset": fragment.row_offset,
+                "row_index": index_in_file,
+            }
             yield sample
             index_in_file += 1
 
@@ -180,13 +192,32 @@ def iter_parquets(
     columns: Sequence[str] | None = None,
     batch_size: int | None = None,
     use_threads: bool = True,
+    resume_cursor: object | None = None,
 ) -> Iterator[Sample]:
     """Iterate parquet row-group fragments in order and yield row samples."""
 
+    resume_path = resume_row = None
+    resume_fragment_row_offset = None
+    if isinstance(resume_cursor, dict) and resume_cursor.get("kind") == "parquet":
+        resume_path = resume_cursor.get("path")
+        resume_row = resume_cursor.get("row_index")
+        resume_fragment_row_offset = resume_cursor.get("fragment_row_offset")
+
     for fragment in fragments:
+        start_index = None
+        if resume_path is not None and isinstance(resume_row, int):
+            if fragment.path != resume_path or fragment.row_offset != resume_fragment_row_offset:
+                continue
+            fragment_end = fragment.row_offset + fragment.num_rows
+            if resume_row >= fragment_end:
+                resume_path = resume_row = resume_fragment_row_offset = None
+                continue
+            start_index = max(fragment.row_offset, resume_row + 1)
+            resume_path = resume_row = resume_fragment_row_offset = None
         yield from iter_parquet(
             fragment,
             columns=columns,
             batch_size=batch_size,
             use_threads=use_threads,
+            start_index=start_index,
         )

--- a/src/mvp_dataset/sources/tar/dataset.py
+++ b/src/mvp_dataset/sources/tar/dataset.py
@@ -13,10 +13,11 @@ from .utils import iter_tars
 class _TarSourceIter:
     sidecars: tuple[SidecarSpec, ...] = ()
 
-    def __call__(self, shard_stream):
+    def __call__(self, shard_stream, *, resume_cursor=None):
         return iter_tars(
             shard_stream,
             sidecars=self.sidecars or None,
+            resume_cursor=resume_cursor,
         )
 
 

--- a/src/mvp_dataset/sources/tar/utils.py
+++ b/src/mvp_dataset/sources/tar/utils.py
@@ -9,6 +9,7 @@ from collections.abc import Iterator, Sequence
 from pathlib import PurePosixPath
 from typing import Final, cast
 
+from ...core.resume import RESUME_TOKEN_KEY, token_matches
 from ...core.types import PathLikeStr, Sample, SidecarSpec
 
 
@@ -123,6 +124,7 @@ def _require_sample_key(sample: Sample, *, shard_path: PathLikeStr, source_name:
 def iter_tars(
     shard_paths: Iterator[PathLikeStr],
     sidecars: Sequence[SidecarSpec] | None = None,
+    resume_cursor: object | None = None,
 ) -> Iterator[Sample]:
     """Iterate multiple tar shards, optionally merging sidecar tars.
 
@@ -139,9 +141,21 @@ def iter_tars(
             shards raise a :class:`ValueError`.
     """
     key_dot_level = int(os.environ.get("MVP_DATASET_TAR_KEY_DOT_LEVEL", "1"))
+    resume_seen = resume_cursor is None
     for shard_path in shard_paths:
         if not sidecars:
-            yield from iter_tar(shard_path, key_dot_level=key_dot_level)
+            for sample in iter_tar(shard_path, key_dot_level=key_dot_level):
+                token = {
+                    "kind": "tars",
+                    "shard": str(shard_path),
+                    "sample_index_in_shard": sample["__index_in_shard__"],
+                    "key": sample["__key__"],
+                }
+                sample[RESUME_TOKEN_KEY] = token
+                if not resume_seen:
+                    resume_seen = token_matches(token, resume_cursor)
+                    continue
+                yield sample
             continue
 
         # Build one iterator per sidecar alongside the main iterator.
@@ -194,4 +208,14 @@ def iter_tars(
                         raise ValueError(msg)
                     merged[field] = value
 
+            token = {
+                "kind": "tars",
+                "shard": str(shard_path),
+                "sample_index_in_shard": merged["__index_in_shard__"],
+                "key": main_key,
+            }
+            merged[RESUME_TOKEN_KEY] = token
+            if not resume_seen:
+                resume_seen = token_matches(token, resume_cursor)
+                continue
             yield merged

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+
+import pytest
+
+from mvp_dataset import Dataset, TorchLoader
+
+from .helpers import (
+    build_records,
+    normalize_sample,
+    write_jsonl_file,
+    write_lance_dataset,
+    write_lance_table,
+    write_parquet_file,
+    write_tar_shards,
+)
+
+
+def identity_collate(batch: list[object]) -> list[object]:
+    return batch
+
+
+def _build_source(tmp_path, source_kind: str, records: list[dict[str, object]]) -> str | list[str]:
+    if source_kind == "tars":
+        return write_tar_shards(tmp_path, records, num_shards=2)
+    if source_kind == "jsonl":
+        return write_jsonl_file(tmp_path, records)
+    if source_kind == "parquet":
+        return write_parquet_file(tmp_path, records, row_group_size=2)
+    if source_kind == "lance":
+        return write_lance_dataset(tmp_path, records)
+    raise AssertionError(f"unexpected source_kind={source_kind!r}")
+
+
+@pytest.mark.parametrize(
+    ("source_kind", "requires_lance"),
+    [
+        ("tars", False),
+        ("jsonl", False),
+        ("parquet", False),
+        ("lance", True),
+    ],
+)
+def test_dataset_resume_matches_uninterrupted_read(tmp_path, source_kind: str, requires_lance: bool) -> None:
+    if requires_lance and importlib.util.find_spec("lance") is None:
+        pytest.skip("lance is not installed")
+
+    records = build_records(count=8)
+    source = _build_source(tmp_path, source_kind, records)
+
+    full = [normalize_sample(sample) for sample in Dataset.from_source(source_kind, shards=source)]
+
+    partial_dataset = Dataset.from_source(source_kind, shards=source)
+    partial_iter = iter(partial_dataset)
+    prefix = [normalize_sample(next(partial_iter)) for _ in range(3)]
+    state = partial_dataset.state_dict()
+
+    resumed_dataset = Dataset.from_source(source_kind, shards=source)
+    resumed_dataset.load_state_dict(state)
+    resumed = [normalize_sample(sample) for sample in resumed_dataset]
+
+    assert prefix + resumed == full
+
+
+def test_torch_loader_resume_matches_uninterrupted_batches(tmp_path) -> None:
+    records = build_records(count=8)
+    source = write_parquet_file(tmp_path, records, row_group_size=2)
+
+    full_loader = TorchLoader(
+        Dataset.from_source("parquet", shards=source),
+        num_workers=0,
+        batch_size=2,
+        collate_fn=identity_collate,
+    )
+    full = [[normalize_sample(sample) for sample in batch] for batch in full_loader]
+
+    partial_loader = TorchLoader(
+        Dataset.from_source("parquet", shards=source),
+        num_workers=0,
+        batch_size=2,
+        collate_fn=identity_collate,
+    )
+    partial_iter = iter(partial_loader)
+    prefix = [[normalize_sample(sample) for sample in next(partial_iter)] for _ in range(2)]
+    state = partial_loader.state_dict()
+
+    resumed_loader = TorchLoader(
+        Dataset.from_source("parquet", shards=source),
+        num_workers=0,
+        batch_size=2,
+        collate_fn=identity_collate,
+    )
+    resumed_loader.load_state_dict(state)
+    resumed = [[normalize_sample(sample) for sample in batch] for batch in resumed_loader]
+
+    assert prefix + resumed == full
+    assert state["step"] == 2
+
+
+def test_resume_rejects_changed_source_fingerprint(tmp_path) -> None:
+    records = build_records(count=4)
+    source = write_jsonl_file(tmp_path, records)
+    dataset = Dataset.from_source("jsonl", shards=source)
+    next(iter(dataset))
+    state = dataset.state_dict()
+
+    with open(source, "a", encoding="utf-8") as handle:
+        handle.write(json.dumps({"id": "new", "text": "new", "value": 99}, ensure_ascii=True) + "\n")
+
+    with pytest.raises(ValueError, match="source_fingerprint"):
+        Dataset.from_source("jsonl", shards=source).load_state_dict(state)
+
+
+def test_resume_rejects_changed_reader_config(tmp_path) -> None:
+    records = build_records(count=4)
+    source = write_parquet_file(tmp_path, records, row_group_size=2)
+    dataset = Dataset.from_source("parquet", shards=source, columns=("id", "text", "value"))
+    next(iter(dataset))
+    state = dataset.state_dict()
+
+    with pytest.raises(ValueError, match="source_fingerprint"):
+        Dataset.from_source("parquet", shards=source, columns=("id", "value")).load_state_dict(state)
+
+
+def test_resume_rejects_changed_jsonl_ref_fields(tmp_path) -> None:
+    records = build_records(count=4)
+    source = write_jsonl_file(tmp_path, records)
+    dataset = Dataset.from_source("jsonl", shards=source)
+    next(iter(dataset))
+    state = dataset.state_dict()
+
+    with pytest.raises(ValueError, match="source_fingerprint"):
+        Dataset.from_source("jsonl", shards=source, ref_fields=(("payload", str(tmp_path)),)).load_state_dict(state)
+
+
+def test_resume_rejects_runtime_change(tmp_path, monkeypatch) -> None:
+    records = build_records(count=4)
+    source = write_jsonl_file(tmp_path, records)
+    dataset = Dataset.from_source("jsonl", shards=source)
+    next(iter(dataset))
+    state = dataset.state_dict()
+
+    monkeypatch.setenv("WORLD_SIZE", "2")
+    with pytest.raises(ValueError, match="runtime_fingerprint"):
+        Dataset.from_source("jsonl", shards=source).load_state_dict(state)
+
+
+def test_resume_rejects_unsupported_shuffle_stage(tmp_path) -> None:
+    records = build_records(count=4)
+    source = write_jsonl_file(tmp_path, records)
+    dataset = Dataset.from_source("jsonl", shards=source).shuffle(buffer_size=2)
+
+    with pytest.raises(ValueError, match="UnsupportedResumeStage"):
+        dataset.state_dict()
+
+
+def test_lance_resume_matches_uninterrupted_multipart_read(tmp_path) -> None:
+    if importlib.util.find_spec("lance") is None:
+        pytest.skip("lance is not installed")
+
+    records = build_records(count=10)
+    first = write_lance_table(tmp_path, "first.lance", records[:4])
+    second = write_lance_table(tmp_path, "second.lance", records[4:])
+    source = [first, second]
+
+    full = [normalize_sample(sample) for sample in Dataset.from_source("lance", shards=source)]
+
+    partial_dataset = Dataset.from_source("lance", shards=source)
+    partial_iter = iter(partial_dataset)
+    prefix = [normalize_sample(next(partial_iter)) for _ in range(6)]
+    state = partial_dataset.state_dict()
+
+    resumed_dataset = Dataset.from_source("lance", shards=source)
+    resumed_dataset.load_state_dict(state)
+    resumed = [normalize_sample(sample) for sample in resumed_dataset]
+
+    assert prefix + resumed == full
+
+
+def test_lance_resume_rejects_shuffle_mode(tmp_path) -> None:
+    if importlib.util.find_spec("lance") is None:
+        pytest.skip("lance is not installed")
+
+    source = write_lance_dataset(tmp_path, build_records(count=4))
+    dataset = Dataset.from_source("lance", shards=source, shuffle_mode="global")
+
+    with pytest.raises(ValueError, match="UnsupportedResumeSource"):
+        dataset.state_dict()
+
+
+def test_lance_resume_rejects_changed_ref_index_scope(tmp_path) -> None:
+    if importlib.util.find_spec("lance") is None:
+        pytest.skip("lance is not installed")
+
+    source = write_lance_dataset(tmp_path, build_records(count=4))
+    dataset = Dataset.from_source("lance", shards=source, ref_index_scope="shared")
+    next(iter(dataset))
+    state = dataset.state_dict()
+
+    with pytest.raises(ValueError, match="source_fingerprint"):
+        Dataset.from_source("lance", shards=source, ref_index_scope="process").load_state_dict(state)


### PR DESCRIPTION
## Summary

This PR adds resumable dataset iteration so training jobs can checkpoint dataloader progress and continue from the next sample or batch after restart.

## Resume Flow

- Each source reader attaches an internal `__resume_token__` to every yielded sample.
- `Dataset` tracks the latest token before pipeline stages are applied.
- Calling `dataset.state_dict()` records the current step, source kind, runtime fingerprint, source fingerprint, pipeline fingerprint, and latest source cursor.
- Calling `load_state_dict()` validates that the runtime, source configuration, and pipeline still match the saved state.
- After validation, the saved cursor is passed back into the source reader.
- The source reader locates the saved cursor and resumes from the next sample.
- `TorchLoader.state_dict()` wraps the nested dataset state and additionally records loader-level configuration and batch step state.


## How to locate data when resume?

Different source formats use different cursor: 

| Source | Cursor | Resume Complexity |
| --- | --- | --- |
| JSONL | `{"kind": "jsonl", "file": "...", "line_index": 123, "key": "..."}` | Scans to the matching line in the JSONL stream. No byte-offset index is built in this minimal version, so resume is `O(lines before cursor in shard)`. |
| TAR | `{"kind": "tars", "shard": "...", "sample_index_in_shard": 42, "key": "..."}` | Scans to the matching sample in the TAR shard. No member-offset index is built, so resume is `O(samples before cursor in shard)`. |
| Parquet | `{"kind": "parquet", "path": "...", "row_groups": [0, 1], "fragment_row_offset": 0, "row_index": 123}` | Skips unrelated fragments, then starts from `row_index + 1` inside the target fragment. Resume is `O(fragments before cursor + rows before cursor in target fragment)`. |
| Lance | `{"kind": "lance", "dataset_i": 0, "local_index": 123, "global_index": 123}` | For `shuffle_mode="none"`, resumes from `global_index + 1`. Resume is effectively `O(1)` for index generation. |

## Minimal Implementation Scope

This PR intentionally keeps resume support small and explicit:

- Supports `Dataset.state_dict()` / `Dataset.load_state_dict()` for direct dataset iteration.
- Supports `TorchLoader.state_dict()` / `TorchLoader.load_state_dict()` for batch-boundary training resume.
- Primarily targets `TorchLoader(num_workers=0)`; workers and prefetch queues are rebuilt on resume rather than checkpointed.
- Supports deterministic `map`, `select`, and `batch` stages.
- Validates runtime, source, pipeline, and loader fingerprints before restoring state.
- Supports Lance resume only when `shuffle_mode="none"`.

The following cases are intentionally not supported in this minimal version:

- Dataset-level `shuffle`, because the shuffle buffer and RNG state are not checkpointed.
- `assemble` and `unbatch`, because their intermediate stage state is not checkpointed.
- Lance `shuffle_mode="global"` and `shuffle_mode="fragment_aware"`.
- PyTorch worker state and prefetch queues for `num_workers > 0`.
- JSONL byte-offset indexes.
- TAR member-offset indexes.
