### PR TITLE
feat: add mixed dataset source

### DIFF
--- a/src/mvp_dataset/core/dataset.py
+++ b/src/mvp_dataset/core/dataset.py
@@ -294,5 +294,9 @@ class Dataset(TorchIterableDataset):
             from ..sources.lance.dataset import LanceDataset
 
             return LanceDataset.from_source(*args, **kwargs)
+        if source_kind == "mixed":
+            from ..sources.mixed.dataset import MixedDataset
+
+            return MixedDataset.from_source(*args, **kwargs)
         msg = f"[UnsupportedSourceKind] source_kind={source_kind!r}"
         raise ValueError(msg)

--- a/src/mvp_dataset/core/types.py
+++ b/src/mvp_dataset/core/types.py
@@ -144,4 +144,4 @@ class StatefulAssembler(Protocol):
         ...
 
 
-SourceKind = Literal["jsonl", "tar", "parquet", "lance"]
+SourceKind = Literal["jsonl", "tar", "parquet", "lance", "mixed"]

--- a/src/mvp_dataset/sources/__init__.py
+++ b/src/mvp_dataset/sources/__init__.py
@@ -2,7 +2,8 @@
 
 from .jsonl.dataset import JsonlDataset
 from .lance.dataset import LanceDataset
+from .mixed.dataset import MixedDataset
 from .parquet.dataset import ParquetDataset
 from .tar.dataset import TarDataset
 
-__all__ = ["JsonlDataset", "LanceDataset", "ParquetDataset", "TarDataset"]
+__all__ = ["JsonlDataset", "LanceDataset", "MixedDataset", "ParquetDataset", "TarDataset"]

--- a/src/mvp_dataset/sources/mixed/__init__.py
+++ b/src/mvp_dataset/sources/mixed/__init__.py
@@ -1,0 +1,6 @@
+"""Mixed source."""
+
+from .dataset import MixedDataset
+from .types import MixedSourceSpec
+
+__all__ = ["MixedDataset", "MixedSourceSpec"]

--- a/src/mvp_dataset/sources/mixed/dataset.py
+++ b/src/mvp_dataset/sources/mixed/dataset.py
@@ -1,0 +1,123 @@
+"""Mixed dataset source configuration."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+
+from mvp_dataset.core.context import RuntimeContext
+from mvp_dataset.core.dataset import Dataset
+from mvp_dataset.core.resume import stable_fingerprint
+
+from .iterator import _MixedSourceIterator
+from .types import MixedSourceSpec, MixedStrategy
+
+_MIXED_STRATEGIES = {"concat", "round_robin", "weighted_round_robin", "random", "weighted_random"}
+
+
+@dataclass(frozen=True, slots=True)
+class MixedDataset(Dataset):
+    """Dataset configuration for multiple mixed dataset sources."""
+
+    _strategy: MixedStrategy = "weighted_round_robin"
+
+    @classmethod
+    def from_source(
+        cls,
+        sources: Mapping[str, Dataset],
+        context: RuntimeContext | None = None,
+        strategy: MixedStrategy = "weighted_round_robin",
+        weights: Mapping[str, int] | None = None,
+    ):
+        """Build a dataset that mixes multiple child datasets.
+
+        Args:
+            sources: Named child datasets to mix.
+            context: Runtime context used for mixed iteration.
+            strategy: Source selection strategy.
+            weights: Optional per-source weights for weighted round robin.
+
+        Returns:
+            A dataset configured for mixed-source iteration."""
+        if strategy not in _MIXED_STRATEGIES:
+            msg = f"[UnsupportedMixedStrategy] strategy={strategy!r}"
+            raise ValueError(msg)
+
+        source_specs = _normalize_sources(sources, weights)
+        runtime_context = source_specs[0].dataset.context if context is None else context
+        _validate_contexts(source_specs, runtime_context)
+
+        return cls(
+            context=runtime_context,
+            _source=source_specs,
+            _resample=False,
+            _source_kind="mixed",
+            _stages=(),
+            _strategy=strategy,
+        )
+
+    def _build_source_stream(self, *, context: RuntimeContext) -> Iterable[object]:
+        """Build the source iterator for a runtime context."""
+        return _MixedSourceIterator(
+            sources=self._source,
+            context=context,
+            strategy=self._strategy,
+            source_fingerprint=stable_fingerprint(self._source_fingerprint()),
+        )
+
+    def _source_fingerprint(self) -> dict[str, object]:
+        """Return the source portion of the pipeline fingerprint."""
+        return {
+            "kind": "mixed",
+            "strategy": self._strategy,
+            "sources": [
+                {
+                    "name": source.name,
+                    "weight": source.weight,
+                    "runtime": source.dataset.context.fingerprint(),
+                    "pipeline": source.dataset._pipeline_fingerprint(),
+                }
+                for source in self._source
+            ],
+        }
+
+
+def _normalize_sources(
+    sources: Mapping[str, Dataset],
+    weights: Mapping[str, int] | None,
+) -> tuple[MixedSourceSpec, ...]:
+    if not sources:
+        msg = "[EmptyMixedSource] at least one source is required"
+        raise ValueError(msg)
+
+    result: list[MixedSourceSpec] = []
+    seen_names: set[str] = set()
+    for name, dataset in sources.items():
+        weight = 1
+        if weights is not None and name in weights:
+            weight = weights[name]
+        if not isinstance(name, str) or not name:
+            msg = f"[InvalidMixedSourceName] name={name!r}"
+            raise ValueError(msg)
+        if name in seen_names:
+            msg = f"[DuplicateMixedSourceName] name={name!r}"
+            raise ValueError(msg)
+        if not isinstance(dataset, Dataset):
+            msg = f"[InvalidMixedSourceDataset] source={name!r} must be a Dataset"
+            raise TypeError(msg)
+        if not isinstance(weight, int) or weight <= 0:
+            msg = f"[InvalidMixedSourceWeight] source={name!r} weight must be a positive integer"
+            raise ValueError(msg)
+
+        seen_names.add(name)
+        result.append(MixedSourceSpec(name=name, dataset=dataset, weight=weight))
+
+    return tuple(result)
+
+
+def _validate_contexts(sources: tuple[MixedSourceSpec, ...], context: RuntimeContext) -> None:
+    context_fingerprint = context.fingerprint()
+    for source in sources:
+        if source.dataset.context.fingerprint() != context_fingerprint:
+            msg = f"[MixedSourceContextMismatch] source={source.name!r} context does not match mixed context"
+            raise ValueError(msg)

--- a/src/mvp_dataset/sources/mixed/iterator.py
+++ b/src/mvp_dataset/sources/mixed/iterator.py
@@ -1,0 +1,224 @@
+"""Mixed source iterator."""
+
+from __future__ import annotations
+
+import random
+import warnings
+from dataclasses import dataclass, field
+
+from mvp_dataset.core.context import RuntimeContext
+from mvp_dataset.core.iterator import DatasetIterator
+from mvp_dataset.core.resume import ResumeStateError
+
+from .types import MixedSourceSpec, MixedStrategy
+
+_MIXED_STRATEGIES = {"concat", "round_robin", "weighted_round_robin", "random", "weighted_random"}
+
+
+@dataclass(slots=True)
+class _WeightedSourceState:
+    """Runtime state for one weighted child source."""
+
+    spec: MixedSourceSpec
+    iterator: DatasetIterator
+    current: int = 0
+    exhausted: bool = False
+
+
+@dataclass(slots=True)
+class _MixedSourceIterator:
+    """Stateful iterator that mixes multiple dataset streams."""
+
+    sources: tuple[MixedSourceSpec, ...]
+    context: RuntimeContext
+    strategy: MixedStrategy
+    source_fingerprint: str
+    _source_states: list[_WeightedSourceState] = field(init=False)
+    _cursor: int = 0
+    _rng: random.Random = field(init=False)
+
+    def __post_init__(self) -> None:
+        """Initialize child dataset iterators."""
+        if self.strategy not in _MIXED_STRATEGIES:
+            msg = f"[UnsupportedMixedStrategy] strategy={self.strategy!r}"
+            raise ValueError(msg)
+        self._rng = random.Random(self.context.sample_shuffle_seed)
+        self._source_states = [
+            _WeightedSourceState(spec=source, iterator=DatasetIterator(source.dataset, context=self.context))
+            for source in self.sources
+        ]
+
+    def __iter__(self):
+        """Return the iterator object."""
+        return self
+
+    def __next__(self) -> object:
+        """Return the next mixed output item."""
+        while True:
+            state = self._pick_source()
+            if state is None:
+                raise StopIteration
+
+            try:
+                sample = next(state.iterator)
+            except StopIteration:
+                state.exhausted = True
+                continue
+
+            return self._annotate_sample(sample, state.spec.name)
+
+    def state_dict(self) -> dict[str, object]:
+        """Return the resumable state for this object."""
+        return {
+            "kind": "mixed",
+            "strategy": self.strategy,
+            "cursor": self._cursor,
+            "rng_state": self._rng.getstate(),
+            "sources": [
+                {
+                    "name": state.spec.name,
+                    "weight": state.spec.weight,
+                    "current": state.current,
+                    "exhausted": state.exhausted,
+                    "state": state.iterator.state_dict(),
+                }
+                for state in self._source_states
+            ],
+        }
+
+    def load_state_dict(self, state: dict[str, object]) -> None:
+        """Restore this object from a resumable state dictionary."""
+        if state.get("kind") != "mixed":
+            msg = f"[InvalidResumeState] expected source kind='mixed', got={state.get('kind')!r}"
+            raise ResumeStateError(msg)
+        if state.get("strategy") != self.strategy:
+            msg = "[InvalidResumeState] mixed strategy does not match"
+            raise ResumeStateError(msg)
+
+        cursor = state.get("cursor")
+        if not isinstance(cursor, int) or cursor < 0:
+            msg = "[InvalidResumeState] mixed cursor must be a non-negative integer"
+            raise ResumeStateError(msg)
+        try:
+            self._rng.setstate(state.get("rng_state"))
+        except (TypeError, ValueError) as error:
+            msg = "[InvalidResumeState] mixed rng_state is invalid"
+            raise ResumeStateError(msg) from error
+
+        raw_sources = state.get("sources")
+        if not isinstance(raw_sources, list) or len(raw_sources) != len(self._source_states):
+            msg = "[InvalidResumeState] mixed sources must match configured sources"
+            raise ResumeStateError(msg)
+
+        restored: list[_WeightedSourceState] = []
+        for configured, raw_source in zip(self.sources, raw_sources, strict=True):
+            if not isinstance(raw_source, dict):
+                msg = "[InvalidResumeState] mixed source state must be a dict"
+                raise ResumeStateError(msg)
+            if raw_source.get("name") != configured.name or raw_source.get("weight") != configured.weight:
+                msg = "[ResumeSourceMismatch] mixed source name or weight does not match"
+                raise ResumeStateError(msg)
+
+            current = raw_source.get("current")
+            if not isinstance(current, int):
+                msg = "[InvalidResumeState] mixed source current must be an integer"
+                raise ResumeStateError(msg)
+            exhausted = raw_source.get("exhausted")
+            if not isinstance(exhausted, bool):
+                msg = "[InvalidResumeState] mixed source exhausted must be a boolean"
+                raise ResumeStateError(msg)
+            child_state = raw_source.get("state")
+            if not isinstance(child_state, dict):
+                msg = "[InvalidResumeState] mixed source child state must be a dict"
+                raise ResumeStateError(msg)
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", UserWarning)
+                dataset = configured.dataset.load_state_dict(child_state)
+            restored.append(
+                _WeightedSourceState(
+                    spec=configured,
+                    iterator=DatasetIterator(dataset, context=self.context),
+                    current=current,
+                    exhausted=exhausted,
+                )
+            )
+
+        self._source_states = restored
+        self._cursor = cursor
+
+    def fingerprint(self) -> str:
+        """Return a stable fingerprint for resume compatibility checks."""
+        return self.source_fingerprint
+
+    def _pick_source(self) -> _WeightedSourceState | None:
+        """Pick the next source for the configured strategy."""
+        if self.strategy == "concat":
+            return self._pick_concat_source()
+        if self.strategy == "round_robin":
+            return self._pick_round_robin_source()
+        if self.strategy == "weighted_round_robin":
+            return self._pick_weighted_source()
+        if self.strategy == "random":
+            return self._pick_random_source(weighted=False)
+        if self.strategy == "weighted_random":
+            return self._pick_random_source(weighted=True)
+        msg = f"[UnsupportedMixedStrategy] strategy={self.strategy!r}"
+        raise ValueError(msg)
+
+    def _pick_concat_source(self) -> _WeightedSourceState | None:
+        """Pick the current source until it is exhausted, then advance."""
+        while self._cursor < len(self._source_states):
+            state = self._source_states[self._cursor]
+            if not state.exhausted:
+                return state
+            self._cursor += 1
+        return None
+
+    def _pick_round_robin_source(self) -> _WeightedSourceState | None:
+        """Pick the next non-exhausted source in cyclic order."""
+        if not self._source_states:
+            return None
+        for _ in self._source_states:
+            index = self._cursor % len(self._source_states)
+            self._cursor = index + 1
+            state = self._source_states[index]
+            if not state.exhausted:
+                return state
+        return None
+
+    def _pick_weighted_source(self) -> _WeightedSourceState | None:
+        """Pick the next source using smooth weighted round robin."""
+        active = [state for state in self._source_states if not state.exhausted]
+        if not active:
+            return None
+
+        total_weight = sum(state.spec.weight for state in active)
+        for state in active:
+            state.current += state.spec.weight
+
+        selected = max(active, key=lambda state: state.current)
+        selected.current -= total_weight
+        return selected
+
+    def _pick_random_source(self, *, weighted: bool) -> _WeightedSourceState | None:
+        """Pick a random non-exhausted source."""
+        active = [state for state in self._source_states if not state.exhausted]
+        if not active:
+            return None
+        if not weighted:
+            return self._rng.choice(active)
+
+        pick = self._rng.randrange(sum(state.spec.weight for state in active))
+        offset = 0
+        for state in active:
+            offset += state.spec.weight
+            if pick < offset:
+                return state
+        return active[-1]
+
+    def _annotate_sample(self, sample: object, source_name: str) -> object:
+        """Add mixed-source metadata to dictionary samples."""
+        if not isinstance(sample, dict):
+            return sample
+        return {**sample, "__source__": source_name}

--- a/src/mvp_dataset/sources/mixed/types.py
+++ b/src/mvp_dataset/sources/mixed/types.py
@@ -1,0 +1,19 @@
+"""Mixed source types."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from mvp_dataset.core.dataset import Dataset
+
+MixedStrategy = Literal["concat", "round_robin", "weighted_round_robin", "random", "weighted_random"]
+
+
+@dataclass(frozen=True, slots=True)
+class MixedSourceSpec:
+    """One named dataset participating in a mixed source."""
+
+    name: str
+    dataset: Dataset
+    weight: int = 1

--- a/tests/test_mixed.py
+++ b/tests/test_mixed.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import pytest
+
+from mvp_dataset import Dataset, RuntimeContext
+
+from .helpers import write_jsonl_file, write_parquet_file
+
+
+def _records(prefix: str, count: int) -> list[dict[str, object]]:
+    return [{"id": f"{prefix}-{index}", "text": f"text-{index}", "value": index} for index in range(count)]
+
+
+def _ids(stream) -> list[str]:
+    return [str(sample["id"]) for sample in stream]
+
+
+def _build_mixed_dataset(
+    tmp_path,
+    *,
+    context: RuntimeContext | None = None,
+    strategy: str = "weighted_round_robin",
+) -> Dataset:
+    runtime_context = RuntimeContext(seed=11) if context is None else context
+    jsonl_dir = tmp_path / "jsonl"
+    parquet_dir = tmp_path / "parquet"
+    jsonl_dir.mkdir(exist_ok=True)
+    parquet_dir.mkdir(exist_ok=True)
+
+    jsonl = Dataset.from_source(
+        "jsonl",
+        shards=write_jsonl_file(jsonl_dir, _records("jsonl", 4)),
+        context=runtime_context,
+        shuffle_mode="none",
+    )
+    parquet = Dataset.from_source(
+        "parquet",
+        shards=write_parquet_file(parquet_dir, _records("parquet", 2)),
+        context=runtime_context,
+        shuffle_mode="none",
+    )
+    return Dataset.from_source(
+        "mixed",
+        sources={"jsonl": jsonl, "parquet": parquet},
+        strategy=strategy,
+        weights={"jsonl": 2, "parquet": 1},
+    )
+
+
+@pytest.mark.parametrize(
+    ("strategy", "expected_ids", "expected_sources"),
+    [
+        (
+            "concat",
+            ["jsonl-0", "jsonl-1", "jsonl-2", "jsonl-3", "parquet-0", "parquet-1"],
+            ["jsonl", "jsonl", "jsonl", "jsonl", "parquet", "parquet"],
+        ),
+        (
+            "round_robin",
+            ["jsonl-0", "parquet-0", "jsonl-1", "parquet-1", "jsonl-2", "jsonl-3"],
+            ["jsonl", "parquet", "jsonl", "parquet", "jsonl", "jsonl"],
+        ),
+        (
+            "weighted_round_robin",
+            ["jsonl-0", "parquet-0", "jsonl-1", "jsonl-2", "parquet-1", "jsonl-3"],
+            ["jsonl", "parquet", "jsonl", "jsonl", "parquet", "jsonl"],
+        ),
+    ],
+)
+def test_mixed_source_uses_ordered_strategy(tmp_path, strategy, expected_ids, expected_sources) -> None:
+    dataset = _build_mixed_dataset(tmp_path, strategy=strategy)
+
+    observed = list(dataset)
+
+    assert _ids(observed) == expected_ids
+    assert [sample["__source__"] for sample in observed] == expected_sources
+
+
+@pytest.mark.parametrize("strategy", ["random", "weighted_random"])
+def test_mixed_source_random_strategy_is_deterministic(tmp_path, strategy) -> None:
+    dataset = _build_mixed_dataset(tmp_path, strategy=strategy)
+
+    first = list(dataset)
+    second = list(dataset)
+
+    assert _ids(first) == _ids(second)
+    assert sorted(_ids(first)) == ["jsonl-0", "jsonl-1", "jsonl-2", "jsonl-3", "parquet-0", "parquet-1"]
+
+
+def test_mixed_source_resume_matches_continued_iteration(tmp_path) -> None:
+    dataset = _build_mixed_dataset(tmp_path)
+    iterator = iter(dataset)
+
+    consumed = [next(iterator) for _ in range(3)]
+    state = iterator.state_dict()
+    continued = list(iterator)
+
+    with pytest.warns(UserWarning, match="Dataset.load_state_dict"):
+        resumed = dataset.load_state_dict(state)
+
+    assert _ids(consumed + continued) == _ids(dataset)
+    assert _ids(resumed) == _ids(continued)
+
+
+def test_mixed_source_rejects_context_mismatch(tmp_path) -> None:
+    left_dir = tmp_path / "left"
+    right_dir = tmp_path / "right"
+    left_dir.mkdir()
+    right_dir.mkdir()
+    left = Dataset.from_source(
+        "jsonl",
+        shards=write_jsonl_file(left_dir, _records("left", 1)),
+        context=RuntimeContext(seed=1),
+    )
+    right = Dataset.from_source(
+        "jsonl",
+        shards=write_jsonl_file(right_dir, _records("right", 1)),
+        context=RuntimeContext(seed=2),
+    )
+
+    with pytest.raises(ValueError, match="MixedSourceContextMismatch"):
+        Dataset.from_source("mixed", sources={"left": left, "right": right})


### PR DESCRIPTION
## Purpose
Add a mixed dataset source that can combine multiple existing Dataset pipelines through named sources.

## Key changes
- Added `mixed` as a supported `Dataset.from_source` kind.
- Added dict-based `sources={name: dataset}` mixed source configuration.
- Added `concat`, `round_robin`, `weighted_round_robin`, `random`, and `weighted_random` strategies.
- Added resumable mixed iteration with source annotations via `__source__`.
- Added focused mixed source tests.

## Validation commands
- `.venv/bin/python -m ruff check src/mvp_dataset/sources/mixed src/mvp_dataset/core/types.py src/mvp_dataset/core/dataset.py src/mvp_dataset/sources/__init__.py tests/test_mixed.py`
- `.venv/bin/python -m pytest tests/test_mixed.py -q`
- `.venv/bin/python -m pytest -q` *(mixed tests passed; existing distributed/multiprocessing tests failed in this environment due to Gloo hostname resolution and forkserver permission limits)*

## Config impacts
No new dependencies or external configuration required.