### PR TITLE
bug: DataLoadMesh fails on named PyTorch DeviceMesh dimensions

### DIFF
--- a/src/mvp_dataset/core/mesh.py
+++ b/src/mvp_dataset/core/mesh.py
@@ -40,6 +40,29 @@ class DataLoadMesh:
         """Return a stable hash for this immutable value."""
         return hash((id(self.device_mesh), self.dp_dims))
 
+    def _mesh_dim_index(self, dim: str) -> int | str:
+        """Return the integer mesh dimension index for a named mesh dimension."""
+
+        dim_names = getattr(self.device_mesh, "mesh_dim_names", None)
+        if dim_names is None:
+            return dim
+        try:
+            return tuple(dim_names).index(dim)
+        except ValueError as exc:
+            msg = f"mesh dimension {dim!r} not found in {tuple(dim_names)!r}"
+            raise ValueError(msg) from exc
+
+    def _mesh_local_rank(self, dim: str) -> int:
+        """Return local rank for a mesh dimension without requiring process groups."""
+
+        dim_index = self._mesh_dim_index(dim)
+        get_coordinate = getattr(self.device_mesh, "get_coordinate", None)
+        if isinstance(dim_index, int) and get_coordinate is not None:
+            coordinate = get_coordinate()
+            if coordinate is not None:
+                return int(coordinate[dim_index])
+        return self.device_mesh.get_local_rank(dim_index)
+
     @property
     def dp_rank(self) -> int:
         """Flattened rank across all data-parallel dimensions.
@@ -47,8 +70,8 @@ class DataLoadMesh:
         Returns:
             The result of the operation."""
 
-        sizes = [self.device_mesh.size(dim) for dim in self.dp_dims]
-        local_ranks = [self.device_mesh.get_local_rank(dim) for dim in self.dp_dims]
+        sizes = [self.device_mesh.size(self._mesh_dim_index(dim)) for dim in self.dp_dims]
+        local_ranks = [self._mesh_local_rank(dim) for dim in self.dp_dims]
         rank = 0
         for i, lr in enumerate(local_ranks):
             stride = 1
@@ -66,7 +89,7 @@ class DataLoadMesh:
 
         size = 1
         for dim in self.dp_dims:
-            size *= self.device_mesh.size(dim)
+            size *= self.device_mesh.size(self._mesh_dim_index(dim))
         return size
 
     @property
@@ -81,7 +104,7 @@ class DataLoadMesh:
             return True
 
         non_dp_dims = [dim for dim in dim_names if dim not in self.dp_dims]
-        return all(self.device_mesh.get_local_rank(dim) == 0 for dim in non_dp_dims)
+        return all(self._mesh_local_rank(dim) == 0 for dim in non_dp_dims)
 
 
 def _normalize_dp_dims(dp_dims: str | Sequence[str]) -> tuple[str, ...]:

--- a/src/mvp_dataset/core/mesh.py
+++ b/src/mvp_dataset/core/mesh.py
@@ -52,6 +52,17 @@ class DataLoadMesh:
             msg = f"mesh dimension {dim!r} not found in {tuple(dim_names)!r}"
             raise ValueError(msg) from exc
 
+    def _mesh_size(self, dim: str) -> int:
+        """Return mesh dimension size for PyTorch and duck-typed meshes."""
+
+        dim_index = self._mesh_dim_index(dim)
+        try:
+            return int(self.device_mesh.size(dim_index))
+        except (KeyError, TypeError):
+            if dim_index == dim:
+                raise
+            return int(self.device_mesh.size(dim))
+
     def _mesh_local_rank(self, dim: str) -> int:
         """Return local rank for a mesh dimension without requiring process groups."""
 
@@ -61,7 +72,12 @@ class DataLoadMesh:
             coordinate = get_coordinate()
             if coordinate is not None:
                 return int(coordinate[dim_index])
-        return self.device_mesh.get_local_rank(dim_index)
+        try:
+            return int(self.device_mesh.get_local_rank(dim_index))
+        except (KeyError, TypeError):
+            if dim_index == dim:
+                raise
+            return int(self.device_mesh.get_local_rank(dim))
 
     @property
     def dp_rank(self) -> int:
@@ -70,7 +86,7 @@ class DataLoadMesh:
         Returns:
             The result of the operation."""
 
-        sizes = [self.device_mesh.size(self._mesh_dim_index(dim)) for dim in self.dp_dims]
+        sizes = [self._mesh_size(dim) for dim in self.dp_dims]
         local_ranks = [self._mesh_local_rank(dim) for dim in self.dp_dims]
         rank = 0
         for i, lr in enumerate(local_ranks):
@@ -89,7 +105,7 @@ class DataLoadMesh:
 
         size = 1
         for dim in self.dp_dims:
-            size *= self.device_mesh.size(self._mesh_dim_index(dim))
+            size *= self._mesh_size(dim)
         return size
 
     @property

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mvp_dataset.core.mesh import DataLoadMesh
+
+
+@dataclass(frozen=True, slots=True)
+class StringOnlyDeviceMesh:
+    dp_size: int = 2
+    tp_size: int = 3
+    rank: int = 4
+
+    mesh_dim_names = ("dp", "tp")
+
+    def size(self, dim: str) -> int:
+        if dim == "dp":
+            return self.dp_size
+        if dim == "tp":
+            return self.tp_size
+        raise KeyError(dim)
+
+    def get_local_rank(self, dim: str) -> int:
+        if dim == "dp":
+            return self.rank // self.tp_size
+        if dim == "tp":
+            return self.rank % self.tp_size
+        raise KeyError(dim)
+
+
+def test_data_load_mesh_preserves_string_dims_for_duck_typed_meshes() -> None:
+    mesh = DataLoadMesh(device_mesh=StringOnlyDeviceMesh(), dp_dims=("dp",))
+
+    assert mesh.dp_size == 2
+    assert mesh.dp_rank == 1
+    assert not mesh.is_dp_leader


### PR DESCRIPTION
## Summary

- Fix `DataLoadMesh` handling of named PyTorch `DeviceMesh` dimensions.
- Avoid passing string mesh dim names directly into `DeviceMesh.size()` / `DeviceMesh.get_local_rank()`.
- Use `DeviceMesh.mesh_dim_names` to resolve names like `"replicate"` into integer dim indices.

## Problem

- `DataLoadMesh` currently calls:

  ```python
  self.device_mesh.size(dim)
  self.device_mesh.get_local_rank(dim)
where dim can be a string such as "replicate" or "shard". With PyTorch 2.8.0, `DeviceMesh.size("replicate")` may reach the underlying mesh tensor, which are unnamed:
  ```python
  Tensor[None, None, None]
  ```
This causes distributed data loading to fail with: 
```python
RuntimeError: Name 'replicate' not found in Tensor[None, None, None]
```

 - `DeviceMesh.get_local_rank(dim)` can also fail inside DataLoader workers because it resolves process groups, which may not be available in worker processes.

## Added
- `_mesh_dim_index(dim)`:
  - Reads `device_mesh.mesh_dim_names`.
  - Maps string dim names such as `"replicate"` to integer indices.
  - Raises a clear `ValueError` if the dim name is not found.

- `_mesh_local_rank(dim)`:
  - Uses `device_mesh.get_coordinate()` when available.
  - Falls back to `device_mesh.get_local_rank(...)`.
  - Avoids requiring process-group lookup in DataLoader workers.

## Changed
- `DataLoadMesh.dp_rank`
- `DataLoadMesh.dp_size`
- `DataLoadMesh.is_dp_leader`