### PR TITLE
feat: add dataset sampling

### DIFF
--- a/doc/dataset-api.md
+++ b/doc/dataset-api.md
@@ -82,6 +82,52 @@ dataset = dataset.unbatch()
 
 Expands list, tuple, or dictionary-style batches back into samples.
 
+## Subset Operations
+
+`split` and `sample` derive new datasets that cover or sample the source. They
+are supported on all sources except `mixed`. Each derived dataset reads only its
+own data.
+
+### `split(fractions)`
+
+```python
+train, val = dataset.split([0.8, 0.2])          # [8, 2] is equivalent
+train, val, test = dataset.split([0.8, 0.1, 0.1])
+```
+
+Partitions the dataset into disjoint subsets that together cover all data.
+
+- `fractions` are normalized internally, so `[8, 2]` and `[0.8, 0.2]` are the same.
+- Returns a tuple of datasets, one per fraction, in input order.
+- The partition follows source order. Source-level shuffle can be used before
+  splitting when random membership is needed.
+
+### `sample(fraction, *, seed=0)`
+
+```python
+subset = dataset.sample(0.1, seed=0)
+```
+
+Returns a dataset over a seeded random subset.
+
+- `fraction` must be in `(0, 1]` — sampling is without replacement and cannot oversample.
+- Reproducible for a given `seed`.
+
+### Granularity
+
+Selection granularity depends on what the source can read efficiently:
+
+- **lance** — row-exact. `split([0.8, 0.2])` yields exactly 80% / 20% of rows,
+  and `sample(f)` keeps exactly `round(f * num_rows)` rows, reading only those rows.
+- **parquet** — chunk-level, weighted by row count.
+- **tar** / **jsonl** — whole-shard level. Fractions are approximate and bounded
+  by the shard/file count; a single tar or `.jsonl` file is one shard and cannot
+  be split internally.
+
+A subset must keep at least `context.total_slots` units (shards/chunks) for
+unit-based sources, otherwise a `ValueError` is raised. `split`/`sample` cannot
+be stacked on an already-subset `lance` dataset; apply them on the base dataset first.
+
 ## Terminal Operations
 
 ### `consume(factory)`

--- a/src/mvp_dataset/core/dataset.py
+++ b/src/mvp_dataset/core/dataset.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import Callable, Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass
 from dataclasses import replace as dataclass_replace
 
@@ -245,6 +245,44 @@ class Dataset(TorchIterableDataset):
             apply=_UnbatchStage(),
         )
         return self._append_stage(spec)
+
+    def split(self, fractions: Sequence[float]) -> tuple[Dataset, ...]:
+        """Partition this dataset into disjoint subsets covering all data.
+
+        Each returned dataset reads only its own data.
+
+        The default implementation treats each ``_source`` element as one
+        equally weighted unit. Sources override this when they partition at a
+        different granularity or do not support subsetting.
+
+        Args:
+            fractions: Split weights, normalized internally (``[0.8, 0.2]`` and
+                ``[8, 2]`` are equivalent).
+
+        Returns:
+            One dataset per fraction, in the input order."""
+        from .subset import split_units
+
+        return split_units(self, [1.0] * len(self._source), fractions)
+
+    def sample(self, fraction: float, *, seed: int = 0) -> Dataset:
+        """Return a dataset over a seeded random subset of this dataset.
+
+        Sampling is without replacement and cannot oversample
+        (``0 < fraction <= 1``). It is reproducible for a given ``seed``.
+
+        The default implementation treats each ``_source`` element as one equally
+        weighted unit; sources override this for other granularities or to opt out.
+
+        Args:
+            fraction: Fraction of the dataset to keep, in ``(0, 1]``.
+            seed: Seed controlling which data is kept.
+
+        Returns:
+            A new dataset reading only the sampled data."""
+        from .subset import sample_units
+
+        return sample_units(self, [1.0] * len(self._source), fraction, seed)
 
     def consume(self, factory: Callable[[RuntimeContext], Consumer]) -> object:
         """Consume this pipeline eagerly and return a user-defined result.

--- a/src/mvp_dataset/core/subset.py
+++ b/src/mvp_dataset/core/subset.py
@@ -1,0 +1,123 @@
+"""Deterministic subset selection shared by ``split()`` and ``sample()``."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from collections.abc import Sequence
+from dataclasses import replace as dataclass_replace
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .dataset import Dataset
+
+
+def split_offsets(total: int, fractions: Sequence[float]) -> list[int]:
+    """Return integer boundaries that partition ``[0, total)``."""
+    normalized = _normalize_fractions(fractions)
+    cuts = [0]
+    accumulated = 0.0
+    for fraction in normalized[:-1]:
+        accumulated += fraction
+        cut = round(accumulated * total)
+        cuts.append(max(cuts[-1], min(cut, total)))
+    cuts.append(total)
+    return cuts
+
+
+def split_units(dataset: Dataset, weights: Sequence[float], fractions: Sequence[float]) -> tuple[Dataset, ...]:
+    """Partition a unit-based source into disjoint datasets covering all units.
+
+    Each split keeps a contiguous subset of ``dataset._source`` in source order.
+
+    Args:
+        dataset: Source dataset whose ``_source`` is an indexable unit sequence.
+        weights: Per-unit weight used to balance the partition (e.g. row counts).
+        fractions: Split fractions, normalized internally.
+    Returns:
+        One new dataset per fraction, in input order."""
+    normalized = _normalize_fractions(fractions)
+    total_weight = sum(weights)
+    if total_weight <= 0:
+        msg = f"[EmptySubsetSource] source_kind={dataset._source_kind!r} has no units to split"
+        raise ValueError(msg)
+
+    bounds = []
+    accumulated = 0.0
+    for fraction in normalized[:-1]:
+        accumulated += fraction
+        bounds.append(accumulated * total_weight)
+
+    groups: list[list[int]] = [[] for _ in normalized]
+    cumulative = 0.0
+    group_index = 0
+    for unit_index, weight in enumerate(weights):
+        while group_index < len(bounds) and cumulative >= bounds[group_index]:
+            group_index += 1
+        groups[group_index].append(unit_index)
+        cumulative += weight
+
+    return tuple(_subset_dataset(dataset, group) for group in groups)
+
+
+def sample_units(dataset: Dataset, weights: Sequence[float], fraction: float, seed: int) -> Dataset:
+    """Return a dataset over a seeded random subset of a unit-based source.
+
+    Args:
+        dataset: Source dataset whose ``_source`` is an indexable unit sequence.
+        weights: Per-unit weight used to size the subset (e.g. row counts).
+        fraction: Fraction of total weight to keep, in ``(0, 1]``.
+        seed: Seed controlling which units are kept.
+
+    Returns:
+        A new dataset reading only the sampled units."""
+    fraction = float(fraction)
+    if not math.isfinite(fraction) or not 0 < fraction <= 1:
+        msg = f"[InvalidSampleFraction] fraction must be in (0, 1], got={fraction!r}"
+        raise ValueError(msg)
+
+    order = sorted(
+        range(len(weights)),
+        key=lambda index: hashlib.sha256(f"{seed}:{index}".encode()).digest(),
+    )
+    total_weight = sum(weights)
+    if total_weight <= 0:
+        msg = f"[EmptySubsetSource] source_kind={dataset._source_kind!r} has no units to sample"
+        raise ValueError(msg)
+
+    target = fraction * total_weight
+    chosen: list[int] = []
+    cumulative = 0.0
+    for unit_index in order:
+        if cumulative >= target:
+            break
+        chosen.append(unit_index)
+        cumulative += weights[unit_index]
+
+    return _subset_dataset(dataset, chosen)
+
+
+def _normalize_fractions(fractions: Sequence[float]) -> list[float]:
+    values = [float(fraction) for fraction in fractions]
+    if not values:
+        msg = "[InvalidSplitFractions] at least one fraction is required"
+        raise ValueError(msg)
+    if any(not math.isfinite(value) or value <= 0 for value in values):
+        msg = f"[InvalidSplitFractions] all fractions must be positive finite values, got={values!r}"
+        raise ValueError(msg)
+    total = sum(values)
+    return [value / total for value in values]
+
+
+def _subset_dataset(dataset: Dataset, unit_indices: Sequence[int]) -> Dataset:
+    """Build a dataset over the given units, preserving original unit order."""
+    min_units = dataset.context.total_slots
+    if len(unit_indices) < min_units:
+        msg = (
+            f"[InsufficientSubsetUnits] split/sample produced {len(unit_indices)} unit(s) "
+            f"for source_kind={dataset._source_kind!r} but {min_units} slot(s) are required - "
+            f"use a larger fraction or split the source into more shards"
+        )
+        raise ValueError(msg)
+    subset = tuple(dataset._source[index] for index in sorted(unit_indices))
+    return dataclass_replace(dataset, _source=subset, _resume_state=None)

--- a/src/mvp_dataset/sources/lance/dataset.py
+++ b/src/mvp_dataset/sources/lance/dataset.py
@@ -1,12 +1,15 @@
 """Lance dataset source configuration."""
 
+import math
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
+from dataclasses import replace as dataclass_replace
 
 from mvp_dataset.core.context import RuntimeContext
 from mvp_dataset.core.dataset import Dataset
 from mvp_dataset.core.resume import stable_fingerprint
 from mvp_dataset.core.stages import _AssembleStage
+from mvp_dataset.core.subset import split_offsets
 from mvp_dataset.core.types import ShardInput, StageSpec
 
 from .config import resolve_lance_source_config
@@ -19,7 +22,12 @@ from .refs import (
     validate_ref_names,
 )
 from .source import list_lance_sources
-from .types import LanceRefIndexConfigInput, LanceRefResolverConfig, LanceShuffleMode
+from .types import (
+    LanceRefIndexConfigInput,
+    LanceRefResolverConfig,
+    LanceSelection,
+    LanceShuffleMode,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -30,6 +38,7 @@ class LanceDataset(Dataset):
     _columns: tuple[str, ...] | None = None
     _read_batch_size: int = 1024
     _chunk_shuffle: ChunkShuffleConfig | None = None
+    _selection: LanceSelection | None = None
 
     @classmethod
     def from_source(
@@ -111,6 +120,7 @@ class LanceDataset(Dataset):
             source_fingerprint=stable_fingerprint(self._source_fingerprint()),
             shuffle_mode=self._shuffle_mode,
             chunk_config=self._chunk_shuffle,
+            selection=self._selection,
         )
 
     def _source_fingerprint(self) -> dict[str, object]:
@@ -121,6 +131,7 @@ class LanceDataset(Dataset):
             "resample": self._resample,
             "shuffle_mode": self._shuffle_mode,
             "chunk_shuffle": self._chunk_shuffle_fingerprint(),
+            "selection": self._selection_fingerprint(),
             "iter": {
                 "columns": list(self._columns) if self._columns else None,
                 "read_batch_size": self._read_batch_size,
@@ -157,6 +168,78 @@ class LanceDataset(Dataset):
             "k": config.k,
             "row_order": config.row_order,
         }
+
+    def _selection_fingerprint(self) -> dict[str, object] | None:
+        """Return the split/sample selection fingerprint payload."""
+        selection = self._selection
+        if selection is None:
+            return None
+        return {
+            "seed": selection.seed,
+            "start": selection.start,
+            "count": selection.count,
+            "total": selection.total,
+        }
+
+    def split(self, fractions: Sequence[float]) -> tuple[Dataset, ...]:
+        """Partition the Lance dataset into disjoint row subsets covering all rows.
+
+        Splitting is row-exact and efficient: each split reads only its own rows
+        through ``take()``. Splits are contiguous source windows; source-level
+        shuffle can randomize the physical membership.
+
+        Args:
+            fractions: Split weights, normalized internally.
+
+        Returns:
+            One dataset per fraction, in input order."""
+        if self._selection is not None:
+            msg = (
+                "[UnsupportedNestedLanceSubset] apply split()/sample() on the base Lance "
+                "dataset before other subset operations"
+            )
+            raise ValueError(msg)
+        total = self._source[0].total_rows
+        offsets = split_offsets(total, fractions)
+        return tuple(
+            dataclass_replace(
+                self,
+                _selection=LanceSelection(
+                    start=offsets[index],
+                    count=offsets[index + 1] - offsets[index],
+                    total=total,
+                ),
+                _resume_state=None,
+            )
+            for index in range(len(offsets) - 1)
+        )
+
+    def sample(self, fraction: float, *, seed: int = 0) -> Dataset:
+        """Return a dataset over a seeded random row subset of the Lance dataset.
+
+        Sampling is row-exact and efficient: only the sampled rows are read. It is
+        without replacement and cannot oversample (``0 < fraction <= 1``).
+
+        Args:
+            fraction: Fraction of rows to keep, in ``(0, 1]``.
+            seed: Seed controlling which rows are kept.
+
+        Returns:
+            A new dataset reading only the sampled rows."""
+        if self._selection is not None:
+            msg = (
+                "[UnsupportedNestedLanceSubset] apply split()/sample() on the base Lance "
+                "dataset before other subset operations"
+            )
+            raise ValueError(msg)
+        fraction = float(fraction)
+        if not math.isfinite(fraction) or not 0 < fraction <= 1:
+            msg = f"[InvalidSampleFraction] fraction must be in (0, 1], got={fraction!r}"
+            raise ValueError(msg)
+        total = self._source[0].total_rows
+        count = round(fraction * total)
+        selection = LanceSelection(start=0, count=count, total=total, seed=seed)
+        return dataclass_replace(self, _selection=selection, _resume_state=None)
 
     def resolve_ref(
         self,

--- a/src/mvp_dataset/sources/lance/iterator.py
+++ b/src/mvp_dataset/sources/lance/iterator.py
@@ -11,7 +11,7 @@ from mvp_dataset.core.resume import ResumeStateError
 
 from .order import ChunkShuffleConfig, LanceIndexOrder, build_lance_index_order
 from .reader import LanceBatchReader
-from .types import LanceIndexItem, LanceShuffleMode, LanceSource
+from .types import LanceIndexItem, LanceSelection, LanceShuffleMode, LanceSource
 
 
 @dataclass(slots=True)
@@ -26,6 +26,7 @@ class _LanceSourceIterator:
     source_fingerprint: str
     shuffle_mode: LanceShuffleMode = "none"
     chunk_config: ChunkShuffleConfig | None = None
+    selection: LanceSelection | None = None
     round_index: int = 0
     position_in_round: int = 0
     _pending_samples: deque[object] = field(default_factory=deque)
@@ -49,6 +50,7 @@ class _LanceSourceIterator:
             self.context,
             self.shuffle_mode,
             chunk_config=self.chunk_config,
+            selection=self.selection,
         )
         self.batch_reader = LanceBatchReader(self.source)
 

--- a/src/mvp_dataset/sources/lance/order.py
+++ b/src/mvp_dataset/sources/lance/order.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from mvp_dataset.core.context import RuntimeContext
 
-from .types import LanceIndexItem, LanceShuffleMode, LanceSource
+from .types import LanceIndexItem, LanceSelection, LanceShuffleMode, LanceSource
 
 DEFAULT_CHUNK_SHUFFLE_CHUNK_SIZE: Final[int] = 250_000
 DEFAULT_CHUNK_SHUFFLE_K: Final[int] = 8
@@ -90,15 +90,21 @@ def build_lance_index_order(
     shuffle_mode: LanceShuffleMode,
     *,
     chunk_config: ChunkShuffleConfig | None = None,
+    selection: LanceSelection | None = None,
 ) -> LanceIndexOrder:
     """Build the index order implementation for a Lance shuffle mode."""
+    resolved_selection = selection or LanceSelection(
+        start=0,
+        count=source.total_rows,
+        total=source.total_rows,
+    )
     if shuffle_mode == "none":
-        return SequentialIndexOrder(source=source, context=context)
+        return SequentialIndexOrder(source=source, context=context, selection=resolved_selection)
     if shuffle_mode == "global":
-        return GlobalShuffleIndexOrder(source=source, context=context)
+        return GlobalShuffleIndexOrder(source=source, context=context, selection=resolved_selection)
     if shuffle_mode == "chunk":
         config = resolve_chunk_shuffle_config(chunk_config)
-        return ChunkShuffleIndexOrder(source=source, context=context, config=config)
+        return ChunkShuffleIndexOrder(source=source, context=context, selection=resolved_selection, config=config)
 
     msg = f"[InvalidLanceShuffleMode] expected none, global, or chunk, got {shuffle_mode!r}"
     raise ValueError(msg)
@@ -154,65 +160,115 @@ def _map_sorted_global_indexes(source: LanceSource, global_indexes: Sequence[int
 
 
 class LanceIndexOrder(ABC):
-    """Map logical source positions to Lance row indexes in batches."""
+    """Map logical source positions to Lance row indexes in batches.
 
-    def __init__(self, *, source: LanceSource, context: RuntimeContext) -> None:
+    All ordering operates over the *effective* row space defined by the active
+    :class:`LanceSelection` (size ``selection.count``). Effective indexes are
+    translated to source logical positions before source-level ordering maps them
+    to physical rows.
+    """
+
+    _epoch_sorted: bool = False
+
+    def __init__(self, *, source: LanceSource, context: RuntimeContext, selection: LanceSelection) -> None:
         self.source = source
         self.context = context
+        self.selection = selection
 
     def round_size(self, round_index: int) -> int:
         """Return item count assigned to this runtime slot in one round."""
         _ = round_index
-        if self.context.slot >= self.source.total_rows:
+        effective_total = self.selection.count
+        if self.context.slot >= effective_total:
             return 0
-        return ((self.source.total_rows - 1 - self.context.slot) // self.context.total_slots) + 1
+        return ((effective_total - 1 - self.context.slot) // self.context.total_slots) + 1
 
-    @abstractmethod
     def items(self, round_index: int, start: int, count: int) -> list[LanceIndexItem]:
         """Return physical Lance indexes for a logical position range."""
+        effective_indexes = self._effective_indexes(round_index, start, count)
+        selection = self.selection
+        if selection.seed is None:
+            source_positions = [selection.start + effective_index for effective_index in effective_indexes]
+        else:
+            source_positions = [
+                permute_index(selection.start + effective_index, total_rows=selection.total, seed=selection.seed)
+                for effective_index in effective_indexes
+            ]
+        global_indexes = self._global_indexes(round_index, source_positions)
+        if self._epoch_sorted and selection.seed is None:
+            return _map_sorted_global_indexes(self.source, global_indexes)
+        return map_global_indexes(self.source, global_indexes)
 
-    def _global_positions(self, start: int, count: int) -> list[int]:
-        return [self.context.slot + position * self.context.total_slots for position in range(start, start + count)]
+    @abstractmethod
+    def _effective_indexes(self, round_index: int, start: int, count: int) -> list[int]:
+        """Return effective-space indexes (in ``[0, effective_total)``) for a range."""
+
+    @abstractmethod
+    def _global_indexes(self, round_index: int, source_positions: Sequence[int]) -> list[int]:
+        """Map source logical positions to physical global row indexes."""
 
 
 class SequentialIndexOrder(LanceIndexOrder):
     """Non-shuffled deterministic Lance order."""
 
-    def items(self, round_index: int, start: int, count: int) -> list[LanceIndexItem]:
-        """Return sequential Lance indexes for a logical position range."""
+    _epoch_sorted = True
+
+    def _effective_indexes(self, round_index: int, start: int, count: int) -> list[int]:
+        """Return sequential effective indexes for a logical position range."""
         _ = round_index
-        return _map_sorted_global_indexes(self.source, self._global_positions(start, count))
+        return [self.context.slot + position * self.context.total_slots for position in range(start, start + count)]
+
+    def _global_indexes(self, round_index: int, source_positions: Sequence[int]) -> list[int]:
+        """Map source logical positions to physical global row indexes."""
+        _ = round_index
+        return list(source_positions)
 
 
 class GlobalShuffleIndexOrder(LanceIndexOrder):
     """Deterministic global Lance shuffle."""
 
-    def items(self, round_index: int, start: int, count: int) -> list[LanceIndexItem]:
-        """Return globally shuffled Lance indexes for a logical position range."""
-        global_indexes = [
+    def _effective_indexes(self, round_index: int, start: int, count: int) -> list[int]:
+        """Return globally shuffled effective indexes for a logical position range."""
+        step = self.context.total_slots
+        first = self.context.slot + start * step
+        stop = first + count * step
+        return list(range(first, stop, step))
+
+    def _global_indexes(self, round_index: int, source_positions: Sequence[int]) -> list[int]:
+        """Map source logical positions to globally shuffled physical row indexes."""
+        return [
             permute_index(position, total_rows=self.source.total_rows, seed=self.context.seed + round_index)
-            for position in self._global_positions(start, count)
+            for position in source_positions
         ]
-        return map_global_indexes(self.source, global_indexes)
 
 
 class ChunkShuffleIndexOrder(LanceIndexOrder):
     """Deterministic chunk-window Lance shuffle."""
 
-    def __init__(self, *, source: LanceSource, context: RuntimeContext, config: ChunkShuffleConfig) -> None:
-        super().__init__(source=source, context=context)
+    def __init__(
+        self,
+        *,
+        source: LanceSource,
+        context: RuntimeContext,
+        selection: LanceSelection,
+        config: ChunkShuffleConfig,
+    ) -> None:
+        super().__init__(source=source, context=context, selection=selection)
         self.config = config
         self._round_index: int | None = None
         self._round_order: _ChunkRoundOrder | None = None
 
-    def items(self, round_index: int, start: int, count: int) -> list[LanceIndexItem]:
-        """Return chunk-shuffled Lance indexes for a logical position range."""
+    def _effective_indexes(self, round_index: int, start: int, count: int) -> list[int]:
+        """Return chunk-shuffled effective indexes for a logical position range."""
+        step = self.context.total_slots
+        first = self.context.slot + start * step
+        stop = first + count * step
+        return list(range(first, stop, step))
+
+    def _global_indexes(self, round_index: int, source_positions: Sequence[int]) -> list[int]:
+        """Map source logical positions to chunk-shuffled physical row indexes."""
         order = self._order_for_round(round_index)
-        global_indexes = [
-            self._global_index_at(position, round_index=round_index, order=order)
-            for position in self._global_positions(start, count)
-        ]
-        return map_global_indexes(self.source, global_indexes)
+        return [self._global_index_at(position, round_index=round_index, order=order) for position in source_positions]
 
     def _order_for_round(self, round_index: int) -> _ChunkRoundOrder:
         if self._round_index == round_index and self._round_order is not None:
@@ -220,7 +276,8 @@ class ChunkShuffleIndexOrder(LanceIndexOrder):
 
         chunk_size = self.config.chunk_size
         k = self.config.k
-        if self.source.total_rows <= 0:
+        total_rows = self.source.total_rows
+        if total_rows <= 0:
             order = _ChunkRoundOrder(
                 chunk_size=chunk_size,
                 k=k,
@@ -229,7 +286,7 @@ class ChunkShuffleIndexOrder(LanceIndexOrder):
                 window_offsets=(0,),
             )
         else:
-            num_chunks = (self.source.total_rows + chunk_size - 1) // chunk_size
+            num_chunks = (total_rows + chunk_size - 1) // chunk_size
             rng = np.random.default_rng(_mix_seed(self.context.seed, round_index, 0))
             chunk_order = tuple(int(chunk_id) for chunk_id in rng.permutation(num_chunks))
             chunk_offsets = [0]

--- a/src/mvp_dataset/sources/lance/types.py
+++ b/src/mvp_dataset/sources/lance/types.py
@@ -71,6 +71,23 @@ class LanceSource:
 
 
 @dataclass(frozen=True, slots=True)
+class LanceSelection:
+    """Row-subset window used by ``split()`` and ``sample()``.
+
+    Attributes:
+        start: Window start in source logical positions.
+        count: Number of rows in the subset (the effective row space size).
+        total: Total rows in the underlying source.
+        seed: Optional seed for sample membership permutation.
+    """
+
+    start: int
+    count: int
+    total: int
+    seed: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class LanceIndexItem:
     """Physical Lance row location used by the source iterator."""
 

--- a/src/mvp_dataset/sources/mixed/dataset.py
+++ b/src/mvp_dataset/sources/mixed/dataset.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 
 from mvp_dataset.core.context import RuntimeContext
@@ -55,6 +55,16 @@ class MixedDataset(Dataset):
             _stages=(),
             _strategy=strategy,
         )
+
+    def split(self, fractions: Sequence[float]) -> tuple[Dataset, ...]:
+        """Mixed sources cannot be split; split each child dataset instead."""
+        msg = f"[UnsupportedSubsetSource] source_kind={self._source_kind!r} does not support split()"
+        raise ValueError(msg)
+
+    def sample(self, fraction: float, *, seed: int = 0) -> Dataset:
+        """Mixed sources cannot be sampled; sample each child dataset instead."""
+        msg = f"[UnsupportedSubsetSource] source_kind={self._source_kind!r} does not support sample()"
+        raise ValueError(msg)
 
     def _build_source_stream(self, *, context: RuntimeContext) -> Iterable[object]:
         """Build the source iterator for a runtime context."""

--- a/src/mvp_dataset/sources/parquet/dataset.py
+++ b/src/mvp_dataset/sources/parquet/dataset.py
@@ -76,6 +76,18 @@ class ParquetDataset(Dataset):
             _shuffle_mode=shuffle_mode,
         )
 
+    def split(self, fractions: Sequence[float]) -> tuple[Dataset, ...]:
+        """Partition the dataset by chunks weighted by row count."""
+        from mvp_dataset.core.subset import split_units
+
+        return split_units(self, [float(chunk.num_rows) for chunk in self._source], fractions)
+
+    def sample(self, fraction: float, *, seed: int = 0) -> Dataset:
+        """Sample a subset by chunks weighted by row count."""
+        from mvp_dataset.core.subset import sample_units
+
+        return sample_units(self, [float(chunk.num_rows) for chunk in self._source], fraction, seed)
+
     def _build_source_stream(self, *, context: RuntimeContext) -> Iterable[object]:
         """Build the source iterator for a runtime context."""
         return _ParquetSourceIterator(

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mvp_dataset import Dataset
+from mvp_dataset.core.context import RuntimeContext
+
+from .helpers import (
+    build_records,
+    normalize_sample,
+    write_lance_dataset,
+    write_parquet_file,
+    write_tar_shards,
+)
+
+_SOURCE_CASES = ["tar", "jsonl", "parquet", "lance"]
+
+
+def _write_jsonl_shards(root, records: list[dict[str, object]], *, num_shards: int) -> list[str]:
+    root.mkdir(parents=True, exist_ok=True)
+    paths: list[str] = []
+    for shard_index in range(num_shards):
+        path = root / f"shard_{shard_index:06d}.jsonl"
+        with path.open("w", encoding="utf-8") as handle:
+            for record in records[shard_index::num_shards]:
+                handle.write(json.dumps(record, ensure_ascii=True) + "\n")
+        paths.append(str(path))
+    return paths
+
+
+def _build_source(tmp_path, source_kind: str, records: list[dict[str, object]]):
+    if source_kind == "tar":
+        return write_tar_shards(tmp_path, records, num_shards=10)
+    if source_kind == "jsonl":
+        return _write_jsonl_shards(tmp_path / "jsonl", records, num_shards=10)
+    if source_kind == "parquet":
+        return write_parquet_file(tmp_path, records, row_group_size=2)
+    if source_kind == "lance":
+        pytest.importorskip("lance")
+        return write_lance_dataset(tmp_path, records, max_rows_per_file=5)
+    raise AssertionError(f"unexpected source_kind={source_kind!r}")
+
+
+def _values(dataset: Dataset) -> list[int]:
+    return [int(normalize_sample(sample)["value"]) for sample in dataset]
+
+
+@pytest.mark.parametrize("source_kind", _SOURCE_CASES)
+def test_split_is_disjoint_and_complete(tmp_path, source_kind: str) -> None:
+    records = build_records(count=100)
+    source = _build_source(tmp_path, source_kind, records)
+
+    train, val = Dataset.from_source(source_kind, shards=source).split([0.8, 0.2])
+    train_values = _values(train)
+    val_values = _values(val)
+
+    assert set(train_values).isdisjoint(val_values)
+    assert sorted(train_values + val_values) == [record["value"] for record in records]
+    assert len(train_values) > len(val_values)
+
+
+@pytest.mark.parametrize("source_kind", _SOURCE_CASES)
+def test_split_is_reproducible(tmp_path, source_kind: str) -> None:
+    records = build_records(count=100)
+    source = _build_source(tmp_path, source_kind, records)
+    dataset = Dataset.from_source(source_kind, shards=source)
+
+    first = set(_values(dataset.split([0.8, 0.2])[0]))
+    same = set(_values(dataset.split([0.8, 0.2])[0]))
+
+    assert first == same
+
+
+@pytest.mark.parametrize("source_kind", _SOURCE_CASES)
+def test_split_fractions_are_normalized(tmp_path, source_kind: str) -> None:
+    records = build_records(count=100)
+    source = _build_source(tmp_path, source_kind, records)
+    dataset = Dataset.from_source(source_kind, shards=source)
+
+    ratio_values = set(_values(dataset.split([8, 2])[0]))
+    fraction_values = set(_values(dataset.split([0.8, 0.2])[0]))
+
+    assert ratio_values == fraction_values
+
+
+def test_split_supports_more_than_two_parts(tmp_path) -> None:
+    records = build_records(count=100)
+    source = _build_source(tmp_path, "lance", records)
+
+    train, val, test = Dataset.from_source("lance", shards=source).split([0.8, 0.1, 0.1])
+    train_values, val_values, test_values = _values(train), _values(val), _values(test)
+
+    assert (len(train_values), len(val_values), len(test_values)) == (80, 10, 10)
+    assert sorted(train_values + val_values + test_values) == [record["value"] for record in records]
+
+
+def test_lance_split_is_row_exact(tmp_path) -> None:
+    records = build_records(count=100)
+    source = _build_source(tmp_path, "lance", records)
+
+    train, val = Dataset.from_source("lance", shards=source).split([0.8, 0.2])
+
+    assert len(_values(train)) == 80
+    assert len(_values(val)) == 20
+
+
+def test_lance_split_membership_uses_source_order(tmp_path) -> None:
+    records = build_records(count=100)
+    source = _build_source(tmp_path, "lance", records)
+    dataset = Dataset.from_source("lance", shards=source, shuffle_mode="none")
+
+    train, val = dataset.split([0.8, 0.2])
+
+    assert _values(train) == list(range(80))
+    assert _values(val) == list(range(80, 100))
+
+
+def test_lance_split_membership_can_follow_source_seed(tmp_path) -> None:
+    records = build_records(count=100)
+    source = _build_source(tmp_path, "lance", records)
+
+    seed7 = set(
+        _values(
+            Dataset.from_source("lance", shards=source, context=RuntimeContext(seed=7), shuffle_mode="global").split(
+                [0.8, 0.2]
+            )[0]
+        )
+    )
+    seed13 = set(
+        _values(
+            Dataset.from_source("lance", shards=source, context=RuntimeContext(seed=13), shuffle_mode="global").split(
+                [0.8, 0.2]
+            )[0]
+        )
+    )
+
+    assert len(seed7) == 80
+    assert len(seed13) == 80
+    assert seed7 != seed13
+
+
+@pytest.mark.parametrize("source_kind", _SOURCE_CASES)
+def test_sample_returns_reproducible_subset(tmp_path, source_kind: str) -> None:
+    records = build_records(count=100)
+    source = _build_source(tmp_path, source_kind, records)
+    dataset = Dataset.from_source(source_kind, shards=source)
+    full = set(record["value"] for record in records)
+
+    first = _values(dataset.sample(0.5, seed=7))
+    same = _values(dataset.sample(0.5, seed=7))
+
+    assert first == same
+    assert set(first) <= full
+    assert 0 < len(first) < len(records)
+
+
+def test_lance_sample_count_is_exact(tmp_path) -> None:
+    records = build_records(count=100)
+    source = _build_source(tmp_path, "lance", records)
+
+    sampled = _values(Dataset.from_source("lance", shards=source).sample(0.2, seed=1))
+
+    assert len(sampled) == 20
+    assert len(set(sampled)) == 20
+
+
+@pytest.mark.parametrize("source_kind", _SOURCE_CASES)
+def test_sample_rejects_oversample(tmp_path, source_kind: str) -> None:
+    source = _build_source(tmp_path, source_kind, build_records(count=20))
+    dataset = Dataset.from_source(source_kind, shards=source)
+
+    with pytest.raises(ValueError, match="InvalidSampleFraction"):
+        dataset.sample(1.5)
+    with pytest.raises(ValueError, match="InvalidSampleFraction"):
+        dataset.sample(0.0)
+
+
+def test_split_rejects_invalid_fractions(tmp_path) -> None:
+    source = _build_source(tmp_path, "lance", build_records(count=20))
+    dataset = Dataset.from_source("lance", shards=source)
+
+    with pytest.raises(ValueError, match="InvalidSplitFractions"):
+        dataset.split([0.8, -0.2])
+
+
+def test_unit_source_split_requires_enough_shards(tmp_path, monkeypatch) -> None:
+    records = build_records(count=40)
+    source = _write_jsonl_shards(tmp_path / "jsonl", records, num_shards=4)
+    monkeypatch.setenv("WORLD_SIZE", "2")
+    monkeypatch.setenv("RANK", "0")
+    dataset = Dataset.from_source("jsonl", shards=source, context=RuntimeContext(world_size=2))
+
+    # 4 shards, 20%% -> ~1 shard for val, but 2 slots are required.
+    with pytest.raises(ValueError, match="InsufficientSubsetUnits"):
+        dataset.split([0.8, 0.2])
+
+
+def test_mixed_source_rejects_subset(tmp_path) -> None:
+    records = build_records(count=20)
+    (tmp_path / "a").mkdir()
+    (tmp_path / "b").mkdir()
+    left = Dataset.from_source("jsonl", shards=_write_jsonl_shards(tmp_path / "a", records, num_shards=3))
+    right = Dataset.from_source("jsonl", shards=_write_jsonl_shards(tmp_path / "b", records, num_shards=3))
+    mixed = Dataset.from_source("mixed", {"left": left, "right": right})
+
+    with pytest.raises(ValueError, match="UnsupportedSubsetSource"):
+        mixed.split([0.8, 0.2])
+    with pytest.raises(ValueError, match="UnsupportedSubsetSource"):
+        mixed.sample(0.5)
+
+
+def test_lance_rejects_nested_subset(tmp_path) -> None:
+    source = _build_source(tmp_path, "lance", build_records(count=100))
+    train, _ = Dataset.from_source("lance", shards=source).split([0.8, 0.2])
+
+    with pytest.raises(ValueError, match="UnsupportedNestedLanceSubset"):
+        train.sample(0.5)
+
+
+def test_lance_sample_distributed_union_matches_single_process(tmp_path, monkeypatch) -> None:
+    records = build_records(count=100)
+    source = _build_source(tmp_path, "lance", records)
+
+    def read_rank(world_size: int, rank: int) -> list[int]:
+        monkeypatch.setenv("WORLD_SIZE", str(world_size))
+        monkeypatch.setenv("RANK", str(rank))
+        dataset = Dataset.from_source(
+            "lance", shards=source, context=RuntimeContext(rank=rank, world_size=world_size, seed=5)
+        )
+        return _values(dataset.sample(0.4, seed=2))
+
+    single = set(read_rank(1, 0))
+    sharded = set(read_rank(2, 0)) | set(read_rank(2, 1))
+
+    assert len(single) == 40
+    assert sharded == single
+
+
+def test_lance_split_resume_matches_continuation(tmp_path) -> None:
+    source = _build_source(tmp_path, "lance", build_records(count=100))
+    train, _ = Dataset.from_source("lance", shards=source, shuffle_mode="global").split([0.8, 0.2])
+
+    iterator = iter(train)
+    consumed = [int(normalize_sample(next(iterator))["value"]) for _ in range(10)]
+    state = iterator.state_dict()
+
+    resumed = train.load_state_dict(state)
+    remainder = _values(resumed)
+
+    full = _values(train)
+    assert consumed + remainder == full


### PR DESCRIPTION
## Purpose
Add dataset-level split and sample APIs for source-level subset selection.

## Key changes
- Add `Dataset.split(...)` and `Dataset.sample(...)`.
- Add shared unit-based subset helpers for shard/chunk sources.
- Add row-exact Lance split/sample support through source index selection.
- Add Parquet chunk-level and tar/jsonl shard-level subset support.
- Reject subset operations for mixed sources.
- Document subset API and granularity.

## Validation
- `.venv/bin/python -m pytest tests/test_subset.py -q`
- pre-commit hooks during commit: ruff check, ruff format, isort

## Config impacts
None.