### PR TITLE
feat: add Lance filter API

### DIFF
--- a/doc/dataset-api.md
+++ b/doc/dataset-api.md
@@ -26,6 +26,45 @@ All source constructors accept these common arguments:
 
 Source-specific arguments are documented in [Source Formats](source-formats.md).
 
+## Source Filter
+
+### `filter(predicate, index=None)`
+
+```python
+dataset = Dataset.from_source("lance", "/data/train.lance").filter(
+    "score >= 0.8 AND label IS NOT NULL",
+    index={"scope": "shared"},
+)
+```
+
+Applies a Lance SQL predicate before source sharding, source shuffle, and row projection. Filtering currently supports
+only Lance and must be called before pipeline stages, `split()`, or `sample()`.
+
+A predicate sequence is combined with `OR` logically and executed as independent Lance filter queries. This keeps
+large ID filters bounded without constructing one large SQL expression:
+
+```python
+ids = [line.strip() for line in open("train.ids", encoding="utf-8") if line.strip()]
+predicates = [
+    "id IN (" + ", ".join("'" + value.replace("'", "''") + "'" for value in ids[start : start + 512]) + ")"
+    for start in range(0, len(ids), 512)
+]
+dataset = Dataset.from_source("lance", "/data/train.lance").filter(predicates)
+```
+
+Overlapping predicate results are deduplicated and source order is preserved. Repeated `filter()` calls are combined
+with `AND`, so `filter([p1, p2]).filter(q)` means `(p1 AND q) OR (p2 AND q)`. A Lance scalar index on the ID column is
+recommended because each predicate is a separate query.
+
+The optional index scope controls how the disk-backed filtered-row index is built:
+
+- `"process"`: the current process prepares all missing parts.
+- `"node_local"`: local ranks build parts together; the cache must be visible within the node.
+- `"shared"` (default): all ranks build parts together; the cache must be visible across nodes.
+
+`filter(...).split(...)` and `filter(...).sample(...)` operate on the filtered row space. Lance source shuffle modes
+`none`, `global`, and `chunk` remain supported.
+
 ## Stages
 
 All dataset stages are lazy and immutable. Calling a stage returns a new dataset.

--- a/doc/source-formats.md
+++ b/doc/source-formats.md
@@ -113,6 +113,14 @@ Lance source notes:
 
 - Lance supports exact deterministic global shuffle without materializing a full epoch index list.
 - `chunk` shuffle randomizes chunk order and rows within a bounded chunk window.
+- `dataset.filter(predicate)` accepts a Lance SQL WHERE expression or a sequence of expressions. Sequence entries are
+  OR-combined logically and executed as independent native filtered scans, which supports bounded ID `IN (...)`
+  batches. Matching rows are deduplicated in source order and stored in a disk-backed row index.
+- Filter indexes are split into deterministic fragment parts and memory-mapped at runtime. Set
+  `MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR` when the Lance source is remote or read-only.
+- Select filter index scope with `index={"scope": "process" | "node_local" | "shared"}`. The default is `"shared"`;
+  storage visibility is not detected automatically.
+- Filtering Lance datasets with deleted rows is not supported.
 - Lance reference columns can be resolved with `resolve_ref(...)`.
 - Use `chunk_shuffle={"chunk_size": 65536, "k": 4, "row_order": "sequential"}` to tune chunk shuffle.
 - `row_order` can be `"permuted"` or `"sequential"`. The default is `"permuted"`.

--- a/src/mvp_dataset/core/dataset.py
+++ b/src/mvp_dataset/core/dataset.py
@@ -154,6 +154,19 @@ class Dataset(TorchIterableDataset):
         spec = StageSpec(kind="map", apply=_MapStage(fn))
         return self._append_stage(spec)
 
+    def filter(self, predicate: str | Sequence[str], *, index: dict[str, object] | None = None) -> Dataset:
+        """Return a source-filtered dataset when supported by the backend.
+
+        Args:
+            predicate: Backend-native filter expression or batched expressions.
+            index: Optional backend filter-index configuration.
+
+        Returns:
+            A new filtered dataset."""
+        _ = predicate, index
+        msg = f"[UnsupportedFilter] source kind={self._source_kind!r}"
+        raise NotImplementedError(msg)
+
     def shuffle(self, buffer_size: int, initial: int | None = None) -> Dataset:
         """Append a deterministic sample-level shuffle stage.
 

--- a/src/mvp_dataset/sources/lance/dataset.py
+++ b/src/mvp_dataset/sources/lance/dataset.py
@@ -2,7 +2,7 @@
 
 import math
 from collections.abc import Iterable, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from dataclasses import replace as dataclass_replace
 
 from mvp_dataset.core.context import RuntimeContext
@@ -13,6 +13,7 @@ from mvp_dataset.core.subset import split_offsets
 from mvp_dataset.core.types import ShardInput, StageSpec
 
 from .config import resolve_lance_source_config
+from .filter import prepare_filter_index, resolve_filter_index_config
 from .iterator import _LanceSourceIterator
 from .order import ChunkShuffleConfig, ChunkShuffleInput, resolve_chunk_shuffle_config
 from .refs import (
@@ -23,6 +24,7 @@ from .refs import (
 )
 from .source import list_lance_sources
 from .types import (
+    LanceFilterIndexConfig,
     LanceRefIndexConfigInput,
     LanceRefResolverConfig,
     LanceSelection,
@@ -39,6 +41,8 @@ class LanceDataset(Dataset):
     _read_batch_size: int = 1024
     _chunk_shuffle: ChunkShuffleConfig | None = None
     _selection: LanceSelection | None = None
+    _filter_predicate_groups: tuple[tuple[str, ...], ...] = ()
+    _filter_index_config: LanceFilterIndexConfig = field(default_factory=LanceFilterIndexConfig)
 
     @classmethod
     def from_source(
@@ -111,8 +115,19 @@ class LanceDataset(Dataset):
         if len(self._source) != 1:
             msg = "[InvalidLanceSource] exactly one merged Lance source is required"
             raise RuntimeError(msg)
+        source = self._source[0]
+        filter_index = (
+            prepare_filter_index(
+                source,
+                predicate_groups=self._filter_predicate_groups,
+                context=context,
+                config=self._filter_index_config,
+            )
+            if self._filter_predicate_groups
+            else None
+        )
         return _LanceSourceIterator(
-            source=self._source[0],
+            source=source,
             context=context,
             resample=self._resample,
             columns=self._columns,
@@ -121,6 +136,7 @@ class LanceDataset(Dataset):
             shuffle_mode=self._shuffle_mode,
             chunk_config=self._chunk_shuffle,
             selection=self._selection,
+            filter_index=filter_index,
         )
 
     def _source_fingerprint(self) -> dict[str, object]:
@@ -132,6 +148,7 @@ class LanceDataset(Dataset):
             "shuffle_mode": self._shuffle_mode,
             "chunk_shuffle": self._chunk_shuffle_fingerprint(),
             "selection": self._selection_fingerprint(),
+            "filter": stable_fingerprint(self._filter_predicate_groups) if self._filter_predicate_groups else None,
             "iter": {
                 "columns": list(self._columns) if self._columns else None,
                 "read_batch_size": self._read_batch_size,
@@ -141,6 +158,7 @@ class LanceDataset(Dataset):
                     "uri": dataset.uri,
                     "num_rows": dataset.num_rows,
                     "row_offset": dataset.row_offset,
+                    "version": dataset.version,
                 }
                 for dataset in source.datasets
             ],
@@ -150,6 +168,14 @@ class LanceDataset(Dataset):
                     "uri": ref.uri,
                     "key_column": ref.key_column,
                     "value_column": ref.value_column,
+                    "datasets": [
+                        {
+                            "uri": dataset.uri,
+                            "version": dataset.version,
+                            "num_rows": dataset.num_rows,
+                        }
+                        for dataset in ref.datasets
+                    ],
                     "index_uri": ref.index_uri,
                     "index_offsets_path": ref.index_offsets_path,
                     "index_entries_path": ref.index_entries_path,
@@ -181,6 +207,64 @@ class LanceDataset(Dataset):
             "total": selection.total,
         }
 
+    def filter(self, predicate: str | Sequence[str], *, index: dict[str, object] | None = None) -> Dataset:
+        """Return a dataset over rows matching Lance SQL predicates.
+
+        Args:
+            predicate: A Lance SQL WHERE expression, or a non-empty sequence of expressions combined with ``OR``.
+            index: Optional filter-index config containing ``scope``.
+
+        Returns:
+            A new filtered dataset."""
+        if self._stages or self._selection is not None:
+            msg = "[InvalidFilterPlacement] filter() must be applied before stages, split(), or sample()"
+            raise ValueError(msg)
+        if isinstance(predicate, str):
+            raw_predicates = (predicate,)
+        elif isinstance(predicate, Sequence):
+            raw_predicates = tuple(predicate)
+        else:
+            msg = "[InvalidLanceFilter] predicate must be a string or sequence of strings"
+            raise TypeError(msg)
+        if not raw_predicates:
+            msg = "[InvalidLanceFilter] predicate sequence must be non-empty"
+            raise ValueError(msg)
+
+        predicates: list[str] = []
+        for item in raw_predicates:
+            if not isinstance(item, str):
+                msg = "[InvalidLanceFilter] every predicate must be a string"
+                raise TypeError(msg)
+            item = item.strip()
+            if not item:
+                msg = "[InvalidLanceFilter] predicate must be non-empty"
+                raise ValueError(msg)
+            predicates.append(item)
+
+        group = tuple(dict.fromkeys(predicates))
+        groups = self._filter_predicate_groups
+        if groups and len(groups[-1]) == 1 and len(group) == 1:
+            group = (f"({groups[-1][0]}) AND ({group[0]})",)
+            groups = groups[:-1]
+        config = self._filter_index_config if index is None else resolve_filter_index_config(index)
+        return dataclass_replace(
+            self,
+            _filter_predicate_groups=groups + (group,),
+            _filter_index_config=config,
+            _resume_state=None,
+        )
+
+    def _active_row_count(self) -> int:
+        """Return the row count after source filtering."""
+        if not self._filter_predicate_groups:
+            return self._source[0].total_rows
+        return prepare_filter_index(
+            self._source[0],
+            predicate_groups=self._filter_predicate_groups,
+            context=self.context,
+            config=self._filter_index_config,
+        ).count
+
     def split(self, fractions: Sequence[float]) -> tuple[Dataset, ...]:
         """Partition the Lance dataset into disjoint row subsets covering all rows.
 
@@ -199,7 +283,7 @@ class LanceDataset(Dataset):
                 "dataset before other subset operations"
             )
             raise ValueError(msg)
-        total = self._source[0].total_rows
+        total = self._active_row_count()
         offsets = split_offsets(total, fractions)
         return tuple(
             dataclass_replace(
@@ -236,7 +320,7 @@ class LanceDataset(Dataset):
         if not math.isfinite(fraction) or not 0 < fraction <= 1:
             msg = f"[InvalidSampleFraction] fraction must be in (0, 1], got={fraction!r}"
             raise ValueError(msg)
-        total = self._source[0].total_rows
+        total = self._active_row_count()
         count = round(fraction * total)
         selection = LanceSelection(start=0, count=count, total=total, seed=seed)
         return dataclass_replace(self, _selection=selection, _resume_state=None)
@@ -275,6 +359,13 @@ class LanceDataset(Dataset):
 
         ref_names = validate_ref_names(self._source[0], ref_names)
         source = self._source[0]
+        versioned_refs = []
+        for ref in source.ref_columns:
+            if ref.column in ref_names and not ref.datasets:
+                ref_source = list_lance_sources((ref.uri,) if isinstance(ref.uri, str) else ref.uri)[0]
+                ref = dataclass_replace(ref, datasets=ref_source.datasets)
+            versioned_refs.append(ref)
+        source = dataclass_replace(source, ref_columns=tuple(versioned_refs))
         ref_index = resolve_ref_index_config(index)
 
         factory = LanceResolveRefFactory(
@@ -290,4 +381,4 @@ class LanceDataset(Dataset):
             kind="assemble",
             apply=_AssembleStage(factory=factory, context=stage_context),
         )
-        return self._append_stage(spec)
+        return dataclass_replace(self, _source=(source,))._append_stage(spec)

--- a/src/mvp_dataset/sources/lance/filter.py
+++ b/src/mvp_dataset/sources/lance/filter.py
@@ -1,0 +1,373 @@
+"""Disk-backed Lance filter index."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+import uuid
+from bisect import bisect_left
+from dataclasses import dataclass, field
+from itertools import groupby
+from pathlib import Path
+from urllib.parse import urlsplit
+
+import lance
+import numpy as np
+
+from mvp_dataset.core.context import RuntimeContext
+
+from .types import (
+    LanceFilterIndex,
+    LanceFilterIndexConfig,
+    LanceFilterIndexConfigInput,
+    LanceSource,
+)
+
+FILTER_INDEX_BUILDER_VERSION = 1
+FILTER_INDEX_DIR = "_mvp_filter_index"
+FILTER_INDEX_CACHE_DIR_ENV = "MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR"
+FILTER_INDEX_BUILD_BATCH_SIZE = 65_536
+FILTER_INDEX_MAX_PARTS = 64
+FILTER_INDEX_POLL_SECONDS = 0.25
+FILTER_INDEX_WAIT_TIMEOUT_SECONDS = 30 * 60
+FILTER_INDEX_MANIFEST = "manifest.json"
+_ROW_OFFSET_MASK = (1 << 32) - 1
+
+
+@dataclass(frozen=True, slots=True)
+class _Fragment:
+    dataset_i: int
+    fragment_id: int
+    global_offset: int
+    physical_rows: int
+    dataset: object = field(repr=False, compare=False)
+    handle: object = field(repr=False, compare=False)
+
+
+def resolve_filter_index_config(index: LanceFilterIndexConfigInput) -> LanceFilterIndexConfig:
+    """Return validated Lance filter-index settings."""
+    if index is None:
+        return LanceFilterIndexConfig()
+    if not isinstance(index, dict):
+        msg = "[InvalidLanceFilterIndexConfig] index must be a mapping"
+        raise TypeError(msg)
+    unknown_keys = sorted(set(index) - {"scope"})
+    if unknown_keys:
+        msg = f"[InvalidLanceFilterIndexConfig] unknown config key(s): {', '.join(unknown_keys)}"
+        raise ValueError(msg)
+    scope = index.get("scope", "shared")
+    if scope not in ("shared", "node_local", "process"):
+        msg = f"[InvalidLanceFilterIndexScope] expected shared, node_local, or process, got {scope!r}"
+        raise ValueError(msg)
+    return LanceFilterIndexConfig(scope=scope)
+
+
+def _plan_parts(source: LanceSource) -> tuple[tuple[_Fragment, ...], ...]:
+    fragments: list[_Fragment] = []
+    for dataset_i, spec in enumerate(source.datasets):
+        dataset = lance.dataset(spec.uri, version=spec.version)
+        local_offset = 0
+        for fragment in dataset.get_fragments():
+            metadata = fragment.metadata
+            if metadata.deletion_file is not None:
+                msg = f"[UnsupportedLanceFilterDeletedRows] dataset has deleted rows: {spec.uri}"
+                raise ValueError(msg)
+            physical_rows = int(metadata.physical_rows)
+            fragments.append(
+                _Fragment(
+                    dataset_i=dataset_i,
+                    fragment_id=int(fragment.fragment_id),
+                    global_offset=spec.row_offset + local_offset,
+                    physical_rows=physical_rows,
+                    dataset=dataset,
+                    handle=fragment,
+                )
+            )
+            local_offset += physical_rows
+        if local_offset != spec.num_rows:
+            msg = f"[InvalidLanceFilterSource] expected {spec.num_rows} rows in {spec.uri}, found {local_offset}"
+            raise RuntimeError(msg)
+
+    if not fragments:
+        return ()
+
+    part_count = min(FILTER_INDEX_MAX_PARTS, len(fragments))
+    prefix_rows = [0]
+    for fragment in fragments:
+        prefix_rows.append(prefix_rows[-1] + fragment.physical_rows)
+
+    boundaries = [0]
+    for part_i in range(1, part_count):
+        target = prefix_rows[-1] * part_i / part_count
+        boundary = bisect_left(prefix_rows, target)
+        boundary = max(boundaries[-1] + 1, min(boundary, len(fragments) - (part_count - part_i)))
+        boundaries.append(boundary)
+    boundaries.append(len(fragments))
+    return tuple(tuple(fragments[start:stop]) for start, stop in zip(boundaries[:-1], boundaries[1:], strict=True))
+
+
+def _load_filter_index(index_dir: Path, identity: dict[str, object]) -> tuple[LanceFilterIndex | None, dict[str, int]]:
+    manifest_path = index_dir / FILTER_INDEX_MANIFEST
+    if not manifest_path.is_file():
+        return None, {}
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        parts = [(str(part["file"]), int(part["count"])) for part in manifest["parts"]]
+    except (KeyError, OSError, TypeError, ValueError, json.JSONDecodeError):
+        return None, {}
+    if manifest.get("identity") != identity:
+        return None, {}
+
+    expected_counts = dict(parts)
+    paths: list[str] = []
+    offsets = [0]
+    for file_name, count in parts:
+        path = index_dir / file_name
+        if count < 0 or not path.is_file() or path.stat().st_size != count * np.dtype(np.int64).itemsize:
+            return None, expected_counts
+        paths.append(str(path))
+        offsets.append(offsets[-1] + count)
+    if manifest.get("offsets") != offsets:
+        return None, expected_counts
+    return LanceFilterIndex(paths=tuple(paths), offsets=tuple(offsets), count=offsets[-1]), expected_counts
+
+
+def _build_parts(
+    entries: tuple[tuple[Path, tuple[_Fragment, ...], int | None], ...],
+    predicate_groups: tuple[tuple[str, ...], ...],
+) -> None:
+    pending = []
+    for path, fragments, expected_count in entries:
+        if path.is_file():
+            size = path.stat().st_size
+            if expected_count is None and size % np.dtype(np.int64).itemsize == 0:
+                continue
+            if expected_count is not None and size == expected_count * np.dtype(np.int64).itemsize:
+                continue
+        pending.append((path, fragments))
+    if not pending:
+        return
+
+    fragments = tuple(fragment for _, part in pending for fragment in part)
+    span_start = fragments[0].global_offset
+    span_rows = fragments[-1].global_offset + fragments[-1].physical_rows - span_start
+    direct = len(pending) == 1 and len(predicate_groups) == 1 and len(predicate_groups[0]) == 1
+    bitmap = None
+    tmp_paths = {path: path.with_name(f"{path.name}.tmp-{os.getpid()}-{uuid.uuid4().hex}") for path, _ in pending}
+    output = tmp_paths[pending[0][0]].open("wb") if direct else None
+    try:
+        dataset_groups = tuple(tuple(grouped) for _, grouped in groupby(fragments, key=lambda item: item.dataset_i))
+        for predicates in predicate_groups:
+            group_bitmap = None if direct else np.zeros((span_rows + 7) // 8, dtype=np.uint8)
+            for group in dataset_groups:
+                part_fragment_ids = np.asarray([fragment.fragment_id for fragment in group], dtype=np.int64)
+                part_offsets = np.asarray([fragment.global_offset for fragment in group], dtype=np.int64)
+                sort_order = np.argsort(part_fragment_ids)
+                part_fragment_ids = part_fragment_ids[sort_order]
+                part_offsets = part_offsets[sort_order]
+                for predicate in predicates:
+                    scanner = group[0].dataset.scanner(
+                        fragments=[fragment.handle for fragment in group],
+                        columns=[],
+                        filter=predicate,
+                        with_row_address=True,
+                        scan_in_order=True,
+                        batch_size=FILTER_INDEX_BUILD_BATCH_SIZE,
+                        use_scalar_index=True,
+                    )
+                    for batch in scanner.to_batches():
+                        row_addresses = np.asarray(batch.column("_rowaddr"), dtype=np.uint64)
+                        row_fragment_ids = np.right_shift(row_addresses, 32).astype(np.int64, copy=False)
+                        row_offsets = np.bitwise_and(row_addresses, _ROW_OFFSET_MASK).astype(np.int64, copy=False)
+                        global_indices = (
+                            part_offsets[np.searchsorted(part_fragment_ids, row_fragment_ids)] + row_offsets
+                        )
+                        if group_bitmap is None:
+                            global_indices.tofile(output)
+                            continue
+                        local_indices = global_indices - span_start
+                        np.bitwise_or.at(
+                            group_bitmap,
+                            local_indices >> 3,
+                            np.left_shift(np.uint8(1), (local_indices & 7).astype(np.uint8, copy=False)),
+                        )
+            if group_bitmap is not None:
+                if bitmap is None:
+                    bitmap = group_bitmap
+                else:
+                    np.bitwise_and(bitmap, group_bitmap, out=bitmap)
+
+        if output is not None:
+            output.close()
+            output = None
+        else:
+            for path, part in pending:
+                part_start = part[0].global_offset
+                part_rows = sum(fragment.physical_rows for fragment in part)
+                bit_start = part_start - span_start
+                with tmp_paths[path].open("wb") as part_output:
+                    for row_start in range(0, part_rows, FILTER_INDEX_BUILD_BATCH_SIZE):
+                        row_stop = min(row_start + FILTER_INDEX_BUILD_BATCH_SIZE, part_rows)
+                        absolute_start = bit_start + row_start
+                        bit_offset = absolute_start & 7
+                        bits = np.unpackbits(
+                            bitmap[absolute_start // 8 : (absolute_start + row_stop - row_start + 7) // 8],
+                            bitorder="little",
+                        )[bit_offset : bit_offset + row_stop - row_start]
+                        global_indices = np.flatnonzero(bits).astype(np.int64, copy=False)
+                        global_indices += part_start + row_start
+                        global_indices.tofile(part_output)
+
+        for path, _ in pending:
+            os.replace(tmp_paths[path], path)
+    finally:
+        if output is not None:
+            output.close()
+        for tmp_path in tmp_paths.values():
+            tmp_path.unlink(missing_ok=True)
+
+
+def _build_part(
+    path: Path,
+    fragments: tuple[_Fragment, ...],
+    predicate_groups: tuple[tuple[str, ...], ...],
+    expected_count: int | None = None,
+) -> None:
+    _build_parts(((path, fragments, expected_count),), predicate_groups)
+
+
+def prepare_filter_index(
+    source: LanceSource,
+    *,
+    predicate_groups: tuple[tuple[str, ...], ...],
+    context: RuntimeContext | None,
+    config: LanceFilterIndexConfig,
+) -> LanceFilterIndex:
+    """Build or open the disk-backed row mapping for Lance filter batches."""
+    predicate_hash = hashlib.sha256(
+        json.dumps(predicate_groups, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    identity: dict[str, object] = {
+        "builder_version": FILTER_INDEX_BUILDER_VERSION,
+        "predicate_hash": predicate_hash,
+        "predicate_group_count": len(predicate_groups),
+        "predicate_count": sum(len(group) for group in predicate_groups),
+        "datasets": [
+            {
+                "uri": dataset.uri,
+                "version": dataset.version,
+                "num_rows": dataset.num_rows,
+            }
+            for dataset in source.datasets
+        ],
+    }
+    digest = hashlib.sha256(json.dumps(identity, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()[
+        :32
+    ]
+    raw_cache_dir = os.environ.get(FILTER_INDEX_CACHE_DIR_ENV)
+    if raw_cache_dir:
+        index_root = Path(raw_cache_dir).expanduser()
+    else:
+        source_uri = source.datasets[0].uri
+        if urlsplit(source_uri).scheme:
+            msg = f"[MissingLanceFilterIndexCacheDir] set {FILTER_INDEX_CACHE_DIR_ENV} for URI source {source_uri!r}"
+            raise ValueError(msg)
+        index_root = Path(source_uri) / FILTER_INDEX_DIR
+    index_dir = index_root / f"filter-index-{digest}"
+    index_dir.mkdir(parents=True, exist_ok=True)
+
+    cached, expected_counts = _load_filter_index(index_dir, identity)
+    if cached is not None:
+        return cached
+
+    parts = _plan_parts(source)
+    part_names = [f"part-{part_i:03d}.i64" for part_i in range(len(parts))]
+    if not parts:
+        for dataset in source.datasets:
+            handle = lance.dataset(dataset.uri, version=dataset.version)
+            for group in predicate_groups:
+                for predicate in group:
+                    handle.count_rows(predicate)
+
+    scope = config.scope
+    if context is None or scope == "process":
+        assignment: tuple[int, int] | None = (0, 1)
+        leader = True
+    elif scope == "shared":
+        assignment = (
+            context.rank * context.num_workers + context.worker_id,
+            context.world_size * context.num_workers,
+        )
+        leader = context.rank == 0 and context.worker_id == 0
+    else:
+        assignment = (
+            context.local_rank * context.num_workers + context.worker_id,
+            context.local_world_size * context.num_workers,
+        )
+        leader = context.local_rank == 0 and context.worker_id == 0
+
+    if leader and expected_counts:
+        _build_parts(
+            tuple(
+                (index_dir / part_name, part, expected_counts[part_name])
+                for part_name, part in zip(part_names, parts, strict=True)
+                if part_name in expected_counts
+            ),
+            predicate_groups,
+        )
+
+    if assignment is not None:
+        builder_id, builder_count = assignment
+        if len(predicate_groups) == 1 and len(predicate_groups[0]) == 1:
+            for part_i in range(builder_id, len(parts), builder_count):
+                part_name = part_names[part_i]
+                _build_part(index_dir / part_name, parts[part_i], predicate_groups, expected_counts.get(part_name))
+        else:
+            start = len(parts) * builder_id // builder_count
+            stop = len(parts) * (builder_id + 1) // builder_count
+            _build_parts(
+                tuple(
+                    (
+                        index_dir / part_names[part_i],
+                        parts[part_i],
+                        expected_counts.get(part_names[part_i]),
+                    )
+                    for part_i in range(start, stop)
+                ),
+                predicate_groups,
+            )
+
+    deadline = time.monotonic() + FILTER_INDEX_WAIT_TIMEOUT_SECONDS
+    while True:
+        cached, _ = _load_filter_index(index_dir, identity)
+        if cached is not None:
+            return cached
+
+        part_paths = [index_dir / part_name for part_name in part_names]
+        if leader and all(path.is_file() and path.stat().st_size % 8 == 0 for path in part_paths):
+            counts = [path.stat().st_size // 8 for path in part_paths]
+            offsets = [0]
+            for count in counts:
+                offsets.append(offsets[-1] + count)
+            manifest = {
+                "identity": identity,
+                "parts": [
+                    {"file": part_name, "count": count} for part_name, count in zip(part_names, counts, strict=True)
+                ],
+                "offsets": offsets,
+            }
+            manifest_path = index_dir / FILTER_INDEX_MANIFEST
+            tmp_path = manifest_path.with_name(f"{manifest_path.name}.tmp-{os.getpid()}-{uuid.uuid4().hex}")
+            try:
+                tmp_path.write_text(json.dumps(manifest, sort_keys=True), encoding="utf-8")
+                os.replace(tmp_path, manifest_path)
+            finally:
+                tmp_path.unlink(missing_ok=True)
+            continue
+
+        if time.monotonic() >= deadline:
+            msg = f"[LanceFilterIndexTimeout] scope={scope!r} cache={str(index_dir)!r}"
+            raise TimeoutError(msg)
+        time.sleep(FILTER_INDEX_POLL_SECONDS)

--- a/src/mvp_dataset/sources/lance/iterator.py
+++ b/src/mvp_dataset/sources/lance/iterator.py
@@ -11,7 +11,13 @@ from mvp_dataset.core.resume import ResumeStateError
 
 from .order import ChunkShuffleConfig, LanceIndexOrder, build_lance_index_order
 from .reader import LanceBatchReader
-from .types import LanceIndexItem, LanceSelection, LanceShuffleMode, LanceSource
+from .types import (
+    LanceFilterIndex,
+    LanceIndexItem,
+    LanceSelection,
+    LanceShuffleMode,
+    LanceSource,
+)
 
 
 @dataclass(slots=True)
@@ -27,6 +33,7 @@ class _LanceSourceIterator:
     shuffle_mode: LanceShuffleMode = "none"
     chunk_config: ChunkShuffleConfig | None = None
     selection: LanceSelection | None = None
+    filter_index: LanceFilterIndex | None = None
     round_index: int = 0
     position_in_round: int = 0
     _pending_samples: deque[object] = field(default_factory=deque)
@@ -51,6 +58,7 @@ class _LanceSourceIterator:
             self.shuffle_mode,
             chunk_config=self.chunk_config,
             selection=self.selection,
+            filter_index=self.filter_index,
         )
         self.batch_reader = LanceBatchReader(self.source)
 

--- a/src/mvp_dataset/sources/lance/order.py
+++ b/src/mvp_dataset/sources/lance/order.py
@@ -12,7 +12,13 @@ import numpy as np
 
 from mvp_dataset.core.context import RuntimeContext
 
-from .types import LanceIndexItem, LanceSelection, LanceShuffleMode, LanceSource
+from .types import (
+    LanceFilterIndex,
+    LanceIndexItem,
+    LanceSelection,
+    LanceShuffleMode,
+    LanceSource,
+)
 
 DEFAULT_CHUNK_SHUFFLE_CHUNK_SIZE: Final[int] = 250_000
 DEFAULT_CHUNK_SHUFFLE_K: Final[int] = 8
@@ -91,20 +97,41 @@ def build_lance_index_order(
     *,
     chunk_config: ChunkShuffleConfig | None = None,
     selection: LanceSelection | None = None,
+    filter_index: LanceFilterIndex | None = None,
 ) -> LanceIndexOrder:
     """Build the index order implementation for a Lance shuffle mode."""
+    base_total = source.total_rows if filter_index is None else filter_index.count
     resolved_selection = selection or LanceSelection(
         start=0,
-        count=source.total_rows,
-        total=source.total_rows,
+        count=base_total,
+        total=base_total,
     )
+    if resolved_selection.total != base_total or resolved_selection.start + resolved_selection.count > base_total:
+        msg = "[InvalidLanceSelection] selection must fit the active Lance row space"
+        raise ValueError(msg)
     if shuffle_mode == "none":
-        return SequentialIndexOrder(source=source, context=context, selection=resolved_selection)
+        return SequentialIndexOrder(
+            source=source,
+            context=context,
+            selection=resolved_selection,
+            filter_index=filter_index,
+        )
     if shuffle_mode == "global":
-        return GlobalShuffleIndexOrder(source=source, context=context, selection=resolved_selection)
+        return GlobalShuffleIndexOrder(
+            source=source,
+            context=context,
+            selection=resolved_selection,
+            filter_index=filter_index,
+        )
     if shuffle_mode == "chunk":
         config = resolve_chunk_shuffle_config(chunk_config)
-        return ChunkShuffleIndexOrder(source=source, context=context, selection=resolved_selection, config=config)
+        return ChunkShuffleIndexOrder(
+            source=source,
+            context=context,
+            selection=resolved_selection,
+            config=config,
+            filter_index=filter_index,
+        )
 
     msg = f"[InvalidLanceShuffleMode] expected none, global, or chunk, got {shuffle_mode!r}"
     raise ValueError(msg)
@@ -170,10 +197,32 @@ class LanceIndexOrder(ABC):
 
     _epoch_sorted: bool = False
 
-    def __init__(self, *, source: LanceSource, context: RuntimeContext, selection: LanceSelection) -> None:
+    def __init__(
+        self,
+        *,
+        source: LanceSource,
+        context: RuntimeContext,
+        selection: LanceSelection,
+        filter_index: LanceFilterIndex | None,
+    ) -> None:
         self.source = source
         self.context = context
         self.selection = selection
+        self.filter_index = filter_index
+        self.base_total = source.total_rows if filter_index is None else filter_index.count
+        self._filter_parts: tuple[object, ...] = ()
+        if filter_index is not None:
+            self._filter_parts = tuple(
+                np.empty(0, dtype=np.int64)
+                if filter_index.offsets[index + 1] == filter_index.offsets[index]
+                else np.memmap(
+                    path,
+                    dtype=np.int64,
+                    mode="r",
+                    shape=(filter_index.offsets[index + 1] - filter_index.offsets[index],),
+                )
+                for index, path in enumerate(filter_index.paths)
+            )
 
     def round_size(self, round_index: int) -> int:
         """Return item count assigned to this runtime slot in one round."""
@@ -194,10 +243,22 @@ class LanceIndexOrder(ABC):
                 permute_index(selection.start + effective_index, total_rows=selection.total, seed=selection.seed)
                 for effective_index in effective_indexes
             ]
-        global_indexes = self._global_indexes(round_index, source_positions)
+        global_indexes = self._map_filtered_positions(self._global_indexes(round_index, source_positions))
         if self._epoch_sorted and selection.seed is None:
             return _map_sorted_global_indexes(self.source, global_indexes)
         return map_global_indexes(self.source, global_indexes)
+
+    def _map_filtered_positions(self, positions: Sequence[int]) -> list[int]:
+        if self.filter_index is None or not positions:
+            return list(positions)
+        position_array = np.asarray(positions, dtype=np.int64)
+        offsets = np.asarray(self.filter_index.offsets, dtype=np.int64)
+        part_ids = np.searchsorted(offsets, position_array, side="right") - 1
+        global_indexes = np.empty(len(position_array), dtype=np.int64)
+        for part_id in np.unique(part_ids):
+            mask = part_ids == part_id
+            global_indexes[mask] = self._filter_parts[int(part_id)][position_array[mask] - offsets[part_id]]
+        return [int(index) for index in global_indexes]
 
     @abstractmethod
     def _effective_indexes(self, round_index: int, start: int, count: int) -> list[int]:
@@ -237,7 +298,7 @@ class GlobalShuffleIndexOrder(LanceIndexOrder):
     def _global_indexes(self, round_index: int, source_positions: Sequence[int]) -> list[int]:
         """Map source logical positions to globally shuffled physical row indexes."""
         return [
-            permute_index(position, total_rows=self.source.total_rows, seed=self.context.seed + round_index)
+            permute_index(position, total_rows=self.base_total, seed=self.context.seed + round_index)
             for position in source_positions
         ]
 
@@ -252,8 +313,9 @@ class ChunkShuffleIndexOrder(LanceIndexOrder):
         context: RuntimeContext,
         selection: LanceSelection,
         config: ChunkShuffleConfig,
+        filter_index: LanceFilterIndex | None,
     ) -> None:
-        super().__init__(source=source, context=context, selection=selection)
+        super().__init__(source=source, context=context, selection=selection, filter_index=filter_index)
         self.config = config
         self._round_index: int | None = None
         self._round_order: _ChunkRoundOrder | None = None
@@ -276,7 +338,7 @@ class ChunkShuffleIndexOrder(LanceIndexOrder):
 
         chunk_size = self.config.chunk_size
         k = self.config.k
-        total_rows = self.source.total_rows
+        total_rows = self.base_total
         if total_rows <= 0:
             order = _ChunkRoundOrder(
                 chunk_size=chunk_size,
@@ -312,7 +374,7 @@ class ChunkShuffleIndexOrder(LanceIndexOrder):
         return order
 
     def _global_index_at(self, global_position: int, *, round_index: int, order: _ChunkRoundOrder) -> int:
-        if global_position < 0 or global_position >= self.source.total_rows:
+        if global_position < 0 or global_position >= self.base_total:
             msg = "[InvalidLanceChunkShuffle] global position is out of range"
             raise ValueError(msg)
         if self.config.row_order == "sequential":
@@ -345,9 +407,9 @@ class ChunkShuffleIndexOrder(LanceIndexOrder):
 
     def _chunk_row_count(self, chunk_id: int) -> int:
         start = chunk_id * self.config.chunk_size
-        if start >= self.source.total_rows:
+        if start >= self.base_total:
             return 0
-        return min(self.config.chunk_size, self.source.total_rows - start)
+        return min(self.config.chunk_size, self.base_total - start)
 
 
 def permute_index(position: int, *, total_rows: int, seed: int) -> int:

--- a/src/mvp_dataset/sources/lance/reader.py
+++ b/src/mvp_dataset/sources/lance/reader.py
@@ -18,6 +18,10 @@ class LanceBatchReader:
 
     def __init__(self, source: LanceSource) -> None:
         self.source = source
+        self._datasets = tuple(
+            dataset.handle if dataset.handle is not None else lance.dataset(dataset.uri, version=dataset.version)
+            for dataset in source.datasets
+        )
 
     def read(self, indexes: Sequence[LanceIndexItem], *, columns: Sequence[str] | None = None) -> list[Sample]:
         """Read a batch of Lance rows and restore input index order."""
@@ -31,8 +35,7 @@ class LanceBatchReader:
         per_dataset_rows: dict[int, list[Sample]] = {}
         take_indices_type = pa.int64()
         for dataset_i, local_indices in per_dataset_indices.items():
-            dataset = self.source.datasets[dataset_i]
-            dataset_handle = dataset.handle if dataset.handle is not None else lance.dataset(dataset.uri)
+            dataset_handle = self._datasets[dataset_i]
 
             if isinstance(dataset_handle, pa.Table):
                 table = dataset_handle

--- a/src/mvp_dataset/sources/lance/refs/index.py
+++ b/src/mvp_dataset/sources/lance/refs/index.py
@@ -18,14 +18,7 @@ import pyarrow as pa
 
 from mvp_dataset.core.context import RuntimeContext
 
-from ..source import list_lance_sources
-from ..types import (
-    LanceDatasetSpec,
-    LanceRefIndexConfig,
-    LanceRefIndexScope,
-    LanceRefSpec,
-    LanceSource,
-)
+from ..types import LanceRefIndexConfig, LanceRefIndexScope, LanceRefSpec, LanceSource
 
 REF_INDEX_BUILDER_VERSION = 1
 REF_INDEX_MISSING_ROW = -1
@@ -128,68 +121,25 @@ def _resolve_ref_index_root(source: LanceSource) -> Path:
     return Path(source.datasets[0].uri) / REF_INDEX_DIR
 
 
-def _dataset_manifest_fingerprint(uri: str) -> dict[str, Any]:
-    """Return a fingerprint for a Lance dataset manifest."""
-    dataset = lance.dataset(uri)
-    version = getattr(dataset, "version", None)
-    if callable(version):
-        version = version()
-    if version is not None:
-        version = str(version)
-
-    fingerprint: dict[str, Any] = {
-        "uri": uri,
-        "num_rows": dataset.count_rows(),
-        "version": version,
-    }
-
-    versions_dir = Path(uri) / "_versions"
-    if versions_dir.exists():
-        manifests = sorted(versions_dir.glob("*.manifest"))
-        if manifests:
-            latest = manifests[-1]
-            stat = latest.stat()
-            fingerprint["manifest"] = {
-                "name": latest.name,
-                "mtime_ns": stat.st_mtime_ns,
-                "size": stat.st_size,
-            }
-    return fingerprint
-
-
-def _ref_uris(ref: LanceRefSpec) -> tuple[str, ...]:
-    """Return referenced Lance URIs for one reference field."""
-    return (ref.uri,) if isinstance(ref.uri, str) else ref.uri
-
-
 def _ref_manifest_fingerprint(ref: LanceRefSpec) -> dict[str, Any]:
     """Return a fingerprint for reference source manifests."""
-    uris = _ref_uris(ref)
-    if len(uris) == 1:
-        return _dataset_manifest_fingerprint(uris[0])
-    datasets = [_dataset_manifest_fingerprint(uri) for uri in uris]
+    datasets = [
+        {
+            "uri": dataset.uri,
+            "num_rows": dataset.num_rows,
+            "version": dataset.version,
+        }
+        for dataset in ref.datasets
+    ]
     return {
-        "uris": list(uris),
         "datasets": datasets,
-        "num_rows": sum(int(dataset["num_rows"]) for dataset in datasets),
+        "num_rows": sum(dataset.num_rows for dataset in ref.datasets),
     }
 
 
 def _open_ref_value_source(ref: LanceRefSpec) -> LanceSource:
     """Open the value source for a Lance reference field."""
-    source = list_lance_sources(_ref_uris(ref))[0]
-    datasets: list[LanceDatasetSpec] = []
-    for dataset in source.datasets:
-        ds_handle: object = lance.dataset(dataset.uri)
-        datasets.append(
-            LanceDatasetSpec(
-                uri=dataset.uri,
-                num_rows=dataset.num_rows,
-                row_offset=dataset.row_offset,
-                handle=ds_handle,
-            )
-        )
-    return LanceSource(datasets=tuple(datasets), ref_columns=source.ref_columns)
+    return LanceSource(datasets=ref.datasets)
 
 
 def _ref_index_is_valid(
@@ -280,7 +230,9 @@ def _build_ref_index_in_memory(
     global_row_index = 0
     main_columns = [ref.column for ref in active_refs]
     for dataset in source.datasets:
-        for batch in _iter_table_record_batches(lance.dataset(dataset.uri), columns=main_columns):
+        for batch in _iter_table_record_batches(
+            lance.dataset(dataset.uri, version=dataset.version), columns=main_columns
+        ):
             for row in batch.to_pylist():
                 global_row_index += 1
                 for ref in active_refs:
@@ -313,14 +265,16 @@ def _build_ref_index_in_memory(
     for ref in active_refs:
         row_index = 0
         resolved_keys: set[Any] = set()
-        for uri in _ref_uris(ref):
-            for batch in _iter_table_record_batches(lance.dataset(uri), columns=[ref.key_column]):
+        for dataset in ref.datasets:
+            for batch in _iter_table_record_batches(
+                lance.dataset(dataset.uri, version=dataset.version), columns=[ref.key_column]
+            ):
                 for row in batch.to_pylist():
                     key = row[ref.key_column]
                     positions = requested_positions[ref.column].get(key)
                     if positions is not None:
                         if key in resolved_keys:
-                            msg = f"[DuplicateLanceRefKey] duplicate key {key!r} in {uri}:{ref.key_column}"
+                            msg = f"[DuplicateLanceRefKey] duplicate key {key!r} in {dataset.uri}:{ref.key_column}"
                             raise ValueError(msg)
                         resolved_keys.add(key)
                         entries_by_column[ref.column][positions] = row_index
@@ -364,7 +318,9 @@ def _build_ref_index_bucketed(
         global_row_index = 0
         main_columns = [ref.column for ref in active_refs]
         for dataset in source.datasets:
-            for batch in _iter_table_record_batches(lance.dataset(dataset.uri), columns=main_columns):
+            for batch in _iter_table_record_batches(
+                lance.dataset(dataset.uri, version=dataset.version), columns=main_columns
+            ):
                 for row in batch.to_pylist():
                     global_row_index += 1
                     for ref in active_refs:
@@ -427,8 +383,10 @@ def _write_ref_buckets(ref: LanceRefSpec, bucket_dir: Path, *, bucket_count: int
     """Write reference keys to hash buckets."""
     row_index = 0
     with _BucketWriter(bucket_dir) as writer:
-        for uri in _ref_uris(ref):
-            for batch in _iter_table_record_batches(lance.dataset(uri), columns=[ref.key_column]):
+        for dataset in ref.datasets:
+            for batch in _iter_table_record_batches(
+                lance.dataset(dataset.uri, version=dataset.version), columns=[ref.key_column]
+            ):
                 for row in batch.to_pylist():
                     key = row[ref.key_column]
                     key_token = _key_token(key)
@@ -496,7 +454,9 @@ def prepare_ref_indexes(
     active_refs = tuple(ref for ref in source.ref_columns if ref.column in ref_name_set)
     if not active_refs:
         return LanceSource(datasets=source.datasets, ref_columns=())
-
+    if any(not ref.datasets for ref in active_refs):
+        msg = "[UnresolvedLanceRefVersion] reference versions must be resolved before index preparation"
+        raise RuntimeError(msg)
     ref_files = {
         ref.column: {
             "kind": "csr_row_index",
@@ -508,7 +468,14 @@ def prepare_ref_indexes(
     }
     manifest = {
         "builder_version": REF_INDEX_BUILDER_VERSION,
-        "main_datasets": [_dataset_manifest_fingerprint(dataset.uri) for dataset in source.datasets],
+        "main_datasets": [
+            {
+                "uri": dataset.uri,
+                "num_rows": dataset.num_rows,
+                "version": dataset.version,
+            }
+            for dataset in source.datasets
+        ],
         "main_total_rows": source.total_rows,
         "refs": {
             ref.column: {
@@ -573,6 +540,7 @@ def prepare_ref_indexes(
                 uri=ref.uri,
                 key_column=ref.key_column,
                 value_column=ref.value_column,
+                datasets=ref.datasets,
                 index_uri=str(index_dir),
                 index_offsets_path=str(offsets_path),
                 index_entries_path=str(entries_path),

--- a/src/mvp_dataset/sources/lance/source.py
+++ b/src/mvp_dataset/sources/lance/source.py
@@ -23,6 +23,7 @@ def list_lance_sources(dataset_uris: Sequence[PathLikeStr]) -> list[LanceSource]
                 uri=str(uri),
                 num_rows=num_rows,
                 row_offset=row_offset,
+                version=dataset.version,
             )
         )
         row_offset += num_rows

--- a/src/mvp_dataset/sources/lance/types.py
+++ b/src/mvp_dataset/sources/lance/types.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass, field
 from typing import Literal
 
 LanceShuffleMode = Literal["none", "global", "chunk"]
+LanceFilterIndexScope = Literal["shared", "node_local", "process"]
+LanceFilterIndexConfigInput = dict[str, object] | None
 LanceRefIndexScope = Literal["shared", "node_local", "process"]
 LanceRefIndexBuildStrategy = Literal["auto", "in_memory", "bucketed"]
 LanceRefIndexConfigInput = dict[str, object] | None
@@ -18,7 +20,24 @@ class LanceDatasetSpec:
     uri: str
     num_rows: int
     row_offset: int
+    version: int | str | None = None
     handle: object | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class LanceFilterIndexConfig:
+    """Filter-index build configuration."""
+
+    scope: LanceFilterIndexScope = "shared"
+
+
+@dataclass(frozen=True, slots=True)
+class LanceFilterIndex:
+    """Disk-backed mapping from filtered positions to source row indexes."""
+
+    paths: tuple[str, ...]
+    offsets: tuple[int, ...]
+    count: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -29,6 +48,7 @@ class LanceRefSpec:
     uri: str | tuple[str, ...]
     key_column: str
     value_column: str
+    datasets: tuple[LanceDatasetSpec, ...] = ()
     index_uri: str | None = None
     index_offsets_path: str | None = None
     index_entries_path: str | None = None

--- a/tests/test_lance_filter.py
+++ b/tests/test_lance_filter.py
@@ -1,0 +1,458 @@
+from __future__ import annotations
+
+import json
+import multiprocessing
+import os
+import pickle
+import queue
+import traceback
+
+import pytest
+
+from mvp_dataset import Dataset
+from mvp_dataset.core.context import RuntimeContext
+
+from .helpers import (
+    build_records,
+    write_jsonl_file,
+    write_lance_dataset,
+    write_lance_table,
+)
+
+
+def _values(dataset: Dataset) -> list[int]:
+    return [int(sample["value"]) for sample in dataset]
+
+
+def _distributed_filter_worker(
+    source: str,
+    cache_dir: str,
+    filter_arg,
+    rank: int,
+    world_size: int,
+    worker_id: int,
+    num_workers: int,
+    results,
+) -> None:
+    try:
+        os.environ.update(
+            RANK=str(rank),
+            WORLD_SIZE=str(world_size),
+            LOCAL_RANK=str(rank),
+            LOCAL_WORLD_SIZE=str(world_size),
+            WORKER=str(worker_id),
+            NUM_WORKERS=str(num_workers),
+            MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR=cache_dir,
+        )
+        from mvp_dataset.sources.lance import filter as lance_filter
+
+        lance_filter.FILTER_INDEX_WAIT_TIMEOUT_SECONDS = 20
+        built_parts = []
+        build_parts = lance_filter._build_parts
+
+        def tracked_build_parts(entries, predicate_groups):
+            built_parts.extend(path.name for path, _, _ in entries)
+            return build_parts(entries, predicate_groups)
+
+        lance_filter._build_parts = tracked_build_parts
+        dataset = Dataset.from_source(
+            "lance",
+            source,
+            context=RuntimeContext(
+                rank=rank,
+                world_size=world_size,
+                local_rank=rank,
+                local_world_size=world_size,
+                worker_id=worker_id,
+                num_workers=num_workers,
+            ),
+        ).filter(filter_arg)
+        results.put(("ok", {"values": _values(dataset), "built_parts": built_parts}))
+    except Exception:
+        results.put(("error", traceback.format_exc()))
+
+
+def test_lance_filter_uses_source_order_and_projection(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(tmp_path / "cache"))
+    source = write_lance_dataset(tmp_path, build_records(20), max_rows_per_file=3)
+
+    rows = list(Dataset.from_source("lance", source, columns=["id"]).filter("value >= 4").filter("value < 9"))
+
+    assert [row["id"] for row in rows] == [f"sample-{index}" for index in range(4, 9)]
+    assert all("value" not in row for row in rows)
+    assert [row["__global_index__"] for row in rows] == list(range(4, 9))
+
+
+def test_lance_filter_batches_are_or_combined_deduplicated_and_source_ordered(tmp_path, monkeypatch) -> None:
+    import lance
+
+    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(tmp_path / "cache"))
+    source = write_lance_dataset(tmp_path, build_records(20), max_rows_per_file=3)
+    lance.dataset(source).create_scalar_index("value", "BTREE")
+    filters = []
+    scanner = lance.LanceDataset.scanner
+
+    def tracked_scanner(self, *args, **kwargs):
+        if kwargs.get("filter") is not None:
+            filters.append((kwargs["filter"], kwargs.get("use_scalar_index")))
+        return scanner(self, *args, **kwargs)
+
+    monkeypatch.setattr(lance.LanceDataset, "scanner", tracked_scanner)
+
+    dataset = Dataset.from_source("lance", source).filter(
+        [
+            "value IN (7, 1, 4)",
+            "value IN (4, 2, 7)",
+            "value = 18",
+        ]
+    )
+
+    assert _values(dataset) == [1, 2, 4, 7, 18]
+    assert len(filters) == 3
+    assert {item for item, _ in filters} == {"value IN (7, 1, 4)", "value IN (4, 2, 7)", "value = 18"}
+    assert all(use_scalar_index is True for _, use_scalar_index in filters)
+
+
+def test_lance_filter_batches_preserve_and_across_calls(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(tmp_path / "cache"))
+    source = write_lance_dataset(tmp_path, build_records(20), max_rows_per_file=3)
+
+    dataset = Dataset.from_source("lance", source).filter(["value < 5", "value > 15"]).filter("value % 2 = 0")
+
+    assert _values(dataset) == [0, 2, 4, 16, 18]
+
+    dataset = (
+        Dataset.from_source("lance", source)
+        .filter(["value < 10", "value > 15"])
+        .filter(["value % 2 = 0", "value = 17"])
+    )
+
+    assert _values(dataset) == [0, 2, 4, 6, 8, 16, 17, 18]
+
+
+def test_lance_filter_batches_cross_bitmap_chunk_boundary(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(tmp_path / "cache"))
+    source = write_lance_dataset(tmp_path, build_records(65_540))
+
+    dataset = Dataset.from_source("lance", source).filter(["value IN (0, 65535)", "value IN (65536, 65539)"])
+
+    assert _values(dataset) == [0, 65_535, 65_536, 65_539]
+
+
+@pytest.mark.parametrize("shuffle_mode", ["none", "global", "chunk"])
+def test_lance_filter_supports_source_shuffle(tmp_path, monkeypatch, shuffle_mode: str) -> None:
+    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(tmp_path / "cache"))
+    source = write_lance_dataset(tmp_path, build_records(30), max_rows_per_file=4)
+    chunk_shuffle = {"chunk_size": 4, "k": 2} if shuffle_mode == "chunk" else None
+
+    observed = _values(
+        Dataset.from_source(
+            "lance",
+            source,
+            context=RuntimeContext(seed=17),
+            shuffle_mode=shuffle_mode,
+            chunk_shuffle=chunk_shuffle,
+        ).filter("value % 2 = 0")
+    )
+
+    assert sorted(observed) == list(range(0, 30, 2))
+    if shuffle_mode == "none":
+        assert observed == list(range(0, 30, 2))
+    else:
+        assert observed != list(range(0, 30, 2))
+
+
+def test_lance_filter_split_sample_and_resume(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(tmp_path / "cache"))
+    source = write_lance_dataset(tmp_path, build_records(40), max_rows_per_file=5)
+    dataset = Dataset.from_source("lance", source, shuffle_mode="global").filter("value >= 10")
+
+    left, right = dataset.split([2, 1])
+    assert len(_values(left)) == 20
+    assert len(_values(right)) == 10
+    sampled = _values(dataset.sample(0.2, seed=7))
+    assert len(sampled) == 6
+    assert set(sampled) <= set(range(10, 40))
+
+    iterator = iter(left)
+    consumed = [int(next(iterator)["value"]) for _ in range(4)]
+    state = iterator.state_dict()
+    with pytest.warns(UserWarning, match="Dataset.load_state_dict"):
+        resumed = left.load_state_dict(state)
+    assert consumed + _values(resumed) == _values(left)
+
+
+def test_lance_filter_preserves_multi_source_global_indexes(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(tmp_path / "cache"))
+    left_root = tmp_path / "left"
+    right_root = tmp_path / "right"
+    left_root.mkdir()
+    right_root.mkdir()
+    left = write_lance_dataset(left_root, build_records(6), max_rows_per_file=2)
+    right_records = [{**row, "id": f"right-{row['id']}", "value": int(row["value"]) + 6} for row in build_records(6)]
+    right = write_lance_dataset(right_root, right_records, max_rows_per_file=2)
+
+    rows = list(Dataset.from_source("lance", [left, right]).filter(["value IN (4, 6, 8)", "value IN (5, 7)"]))
+
+    assert [row["value"] for row in rows] == [4, 5, 6, 7, 8]
+    assert [row["__global_index__"] for row in rows] == [4, 5, 6, 7, 8]
+    assert [row["__local_index__"] for row in rows] == [4, 5, 0, 1, 2]
+
+
+def test_lance_filter_resolve_ref_uses_original_global_indexes(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(tmp_path / "filter-cache"))
+    monkeypatch.setenv("MVP_DATASET_LANCE_REF_INDEX_CACHE_DIR", str(tmp_path / "ref-cache"))
+    main = write_lance_table(
+        tmp_path,
+        "main.lance",
+        [{"id": index, "value": index, "image": f"image-{index}"} for index in range(8)],
+    )
+    refs = write_lance_table(
+        tmp_path,
+        "refs.lance",
+        [{"key": f"image-{index}", "payload": f"bytes-{index}"} for index in range(8)],
+    )
+    dataset = Dataset.from_source(
+        "lance",
+        main,
+        ref_columns={"image": {"uri": refs, "key_column": "key", "value_column": "payload"}},
+    ).filter("value IN (1, 4, 7)")
+
+    rows = list(dataset.resolve_ref(["image"], index={"scope": "process"}))
+
+    assert [row["__global_index__"] for row in rows] == [1, 4, 7]
+    assert [row["image"] for row in rows] == ["bytes-1", "bytes-4", "bytes-7"]
+
+
+def test_lance_filter_cache_is_picklable_and_reused(tmp_path, monkeypatch) -> None:
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(cache_dir))
+    source = write_lance_dataset(tmp_path, build_records(20), max_rows_per_file=2)
+    dataset = Dataset.from_source("lance", source).filter("value >= 5")
+
+    pickle.dumps(dataset)
+    assert _values(dataset) == list(range(5, 20))
+    manifest = next(cache_dir.rglob("manifest.json"))
+    part_mtimes = {path.name: path.stat().st_mtime_ns for path in manifest.parent.glob("part-*.i64")}
+    assert len(part_mtimes) > 1
+
+    assert _values(dataset) == list(range(5, 20))
+    assert {path.name: path.stat().st_mtime_ns for path in manifest.parent.glob("part-*.i64")} == part_mtimes
+    metadata = json.loads(manifest.read_text(encoding="utf-8"))
+    assert metadata["offsets"][-1] == 15
+
+
+def test_lance_filter_warm_cache_skips_fragment_planning(tmp_path, monkeypatch) -> None:
+    from mvp_dataset.sources.lance import filter as lance_filter
+
+    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(tmp_path / "cache"))
+    source = write_lance_dataset(tmp_path, build_records(12), max_rows_per_file=2)
+    dataset = Dataset.from_source("lance", source).filter("value >= 5")
+    assert _values(dataset) == list(range(5, 12))
+
+    monkeypatch.setattr(lance_filter, "_plan_parts", lambda _source: pytest.fail("warm cache was replanned"))
+    assert _values(dataset) == list(range(5, 12))
+
+
+def test_lance_filter_rebuilds_truncated_part(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(tmp_path / "cache"))
+    source = write_lance_dataset(tmp_path, build_records(20), max_rows_per_file=2)
+    dataset = Dataset.from_source("lance", source).filter("value >= 5")
+    assert _values(dataset) == list(range(5, 20))
+
+    manifest_path = next((tmp_path / "cache").rglob("manifest.json"))
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    part = next(part for part in manifest["parts"] if part["count"] > 0)
+    part_path = manifest_path.parent / part["file"]
+    with part_path.open("r+b") as handle:
+        handle.truncate(part_path.stat().st_size - 8)
+
+    assert _values(dataset) == list(range(5, 20))
+
+
+def test_lance_source_without_filter_does_not_enumerate_fragments(tmp_path, monkeypatch) -> None:
+    import lance
+
+    source = write_lance_dataset(tmp_path, build_records(8), max_rows_per_file=2)
+    monkeypatch.setattr(lance.LanceDataset, "get_fragments", lambda _self: pytest.fail("fragments were enumerated"))
+
+    assert _values(Dataset.from_source("lance", source)) == list(range(8))
+
+
+def test_lance_filter_handles_empty_results(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(tmp_path / "cache"))
+    source = write_lance_dataset(tmp_path, build_records(8), max_rows_per_file=2)
+
+    dataset = Dataset.from_source("lance", source).filter("value < 0")
+
+    assert list(dataset) == []
+    assert list(dataset.sample(0.5)) == []
+
+
+def test_lance_filter_validates_predicate_for_zero_fragment_source(tmp_path, monkeypatch) -> None:
+    import lance
+    import pyarrow as pa
+
+    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(tmp_path / "cache"))
+    source = tmp_path / "empty.lance"
+    lance.write_dataset(pa.table({"value": pa.array([], type=pa.int64())}), source)
+
+    assert list(Dataset.from_source("lance", str(source)).filter("value > 0")) == []
+    with pytest.raises(OSError, match="No field named missing"):
+        list(Dataset.from_source("lance", str(source)).filter("missing > 0"))
+
+
+def test_lance_filter_and_ref_index_use_discovered_version(tmp_path, monkeypatch) -> None:
+    import lance
+    import pyarrow as pa
+
+    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(tmp_path / "filter-cache"))
+    monkeypatch.setenv("MVP_DATASET_LANCE_REF_INDEX_CACHE_DIR", str(tmp_path / "ref-cache"))
+    main = write_lance_table(
+        tmp_path,
+        "main.lance",
+        [{"id": index, "value": index, "image": f"image-{index}"} for index in range(8)],
+    )
+    refs = write_lance_table(
+        tmp_path,
+        "refs.lance",
+        [{"key": f"image-{index}", "payload": f"bytes-{index}"} for index in range(8)],
+    )
+    dataset = (
+        Dataset.from_source(
+            "lance",
+            main,
+            ref_columns={"image": {"uri": refs, "key_column": "key", "value_column": "payload"}},
+        )
+        .filter("value >= 0")
+        .resolve_ref(["image"], index={"scope": "process"})
+    )
+    lance.write_dataset(pa.Table.from_pylist([{"id": 8, "value": 8, "image": "image-8"}]), main, mode="append")
+
+    rows = list(dataset)
+    assert [row["value"] for row in rows] == list(range(8))
+    assert [row["image"] for row in rows] == [f"bytes-{index}" for index in range(8)]
+
+
+def test_lance_ref_value_source_uses_discovered_version(tmp_path, monkeypatch) -> None:
+    import lance
+    import pyarrow as pa
+
+    monkeypatch.setenv("MVP_DATASET_LANCE_REF_INDEX_CACHE_DIR", str(tmp_path / "ref-cache"))
+    main = write_lance_table(
+        tmp_path,
+        "main.lance",
+        [{"id": index, "image": f"image-{index}"} for index in range(4)],
+    )
+    refs = write_lance_table(
+        tmp_path,
+        "refs.lance",
+        [{"key": f"image-{index}", "payload": f"bytes-{index}"} for index in range(4)],
+    )
+    dataset = Dataset.from_source(
+        "lance",
+        main,
+        ref_columns={"image": {"uri": refs, "key_column": "key", "value_column": "payload"}},
+    ).resolve_ref(["image"], index={"scope": "process"})
+    reversed_refs = [{"key": f"image-{index}", "payload": f"changed-{index}"} for index in reversed(range(4))]
+    lance.write_dataset(pa.Table.from_pylist(reversed_refs), refs, mode="overwrite")
+
+    rows = list(dataset)
+    assert [row["image"] for row in rows] == [f"bytes-{index}" for index in range(4)]
+
+
+def test_lance_filter_rejects_deleted_rows(tmp_path, monkeypatch) -> None:
+    import lance
+
+    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(tmp_path / "cache"))
+    source = write_lance_dataset(tmp_path, build_records(8), max_rows_per_file=2)
+    lance.dataset(source).delete("value = 1")
+
+    with pytest.raises(ValueError, match="UnsupportedLanceFilterDeletedRows"):
+        list(Dataset.from_source("lance", source).filter("value >= 0"))
+
+
+def test_lance_filter_validates_api_and_placement(tmp_path) -> None:
+    source = write_lance_dataset(tmp_path, build_records(8))
+
+    with pytest.raises(NotImplementedError, match="UnsupportedFilter"):
+        Dataset.from_source("jsonl", write_jsonl_file(tmp_path, build_records(2))).filter("value > 0")
+    with pytest.raises(TypeError, match="predicate must be a string"):
+        Dataset.from_source("lance", source).filter(1)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="predicate must be non-empty"):
+        Dataset.from_source("lance", source).filter("  ")
+    with pytest.raises(ValueError, match="predicate sequence must be non-empty"):
+        Dataset.from_source("lance", source).filter([])
+    with pytest.raises(TypeError, match="every predicate must be a string"):
+        Dataset.from_source("lance", source).filter(["value > 0", 1])  # type: ignore[list-item]
+    with pytest.raises(ValueError, match="predicate must be non-empty"):
+        Dataset.from_source("lance", source).filter(["value > 0", "  "])
+    with pytest.raises(ValueError, match="unknown config key"):
+        Dataset.from_source("lance", source).filter("value > 0", index={"unknown": True})
+    with pytest.raises(ValueError, match="InvalidLanceFilterIndexScope"):
+        Dataset.from_source("lance", source).filter("value > 0", index={"scope": "unknown"})
+    with pytest.raises(ValueError, match="InvalidFilterPlacement"):
+        Dataset.from_source("lance", source).map(lambda row: row).filter("value > 0")
+    with pytest.raises(ValueError, match="InvalidFilterPlacement"):
+        Dataset.from_source("lance", source).split([1, 1])[0].filter("value > 0")
+
+
+def test_lance_filter_requires_cache_dir_for_uri_source(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", raising=False)
+    source = write_lance_dataset(tmp_path, build_records(8))
+
+    with pytest.raises(ValueError, match="MissingLanceFilterIndexCacheDir"):
+        list(Dataset.from_source("lance", f"file://{source}").filter("value > 0"))
+
+
+@pytest.mark.parametrize(
+    "builders",
+    [
+        ((0, 2, 0, 1), (1, 2, 0, 1)),
+        ((0, 1, 0, 2), (0, 1, 1, 2)),
+    ],
+    ids=["ranks", "workers"],
+)
+@pytest.mark.parametrize(
+    ("filter_arg", "expected"),
+    [
+        ("value >= 5", list(range(5, 24))),
+        (["value % 3 = 0", "value % 5 = 0"], [value for value in range(24) if value % 3 == 0 or value % 5 == 0]),
+    ],
+    ids=["single", "batched"],
+)
+def test_lance_filter_builds_shared_parts_across_builders(tmp_path, builders, filter_arg, expected) -> None:
+    source = write_lance_dataset(tmp_path, build_records(24), max_rows_per_file=2)
+    cache_dir = tmp_path / "cache"
+    context = multiprocessing.get_context("spawn")
+    results = context.Queue()
+    processes = [
+        context.Process(
+            target=_distributed_filter_worker,
+            args=(source, str(cache_dir), filter_arg, rank, world_size, worker_id, num_workers, results),
+        )
+        for rank, world_size, worker_id, num_workers in builders
+    ]
+
+    try:
+        for process in processes:
+            process.start()
+        outputs = [results.get(timeout=30) for _ in processes]
+        for process in processes:
+            process.join(timeout=30)
+        assert all(process.exitcode == 0 for process in processes)
+    except queue.Empty:
+        pytest.fail("distributed filter workers timed out")
+    finally:
+        for process in processes:
+            if process.is_alive():
+                process.terminate()
+            process.join()
+
+    errors = [payload for status, payload in outputs if status == "error"]
+    assert not errors, "\n".join(errors)
+    values = [value for status, payload in outputs if status == "ok" for value in payload["values"]]
+    assert sorted(values) == expected
+    assert all(payload["built_parts"] for status, payload in outputs if status == "ok")
+    assert len(list(cache_dir.rglob("part-*.i64"))) > 1
+    assert len(list(cache_dir.rglob("manifest.json"))) == 1


### PR DESCRIPTION
## Summary

- add a lazy Lance-native `filter()` API for SQL predicates and batched predicate lists
- build a disk-backed filtered-row index cooperatively across ranks and DataLoader workers
- preserve source order, deduplicate overlapping predicate batches, and support existing shuffle, split, sample, resume, and reference resolution paths
- document bounded `IN (...)` batches for ID-file filtering

## Why

Large ID filters should use Lance scalar indexes without constructing one oversized SQL predicate or materializing the filtered row mapping in memory. Predicate lists are OR-combined within one call, while repeated `filter()` calls remain AND-combined.

## Validation

- `pre-commit`: ruff check, ruff format, isort
- `pytest tests/test_lance_filter.py -q`: 25 passed
- full available suite: 146 passed, 16 skipped, 2 Torch-dependent tests deselected

## Configuration impact

The filter index defaults to shared scope. Remote or read-only Lance sources require `MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR`.


close #21 