### PR TITLE
enhance: unify persistent cache management

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Detailed docs live in [`doc/`](doc/):
 - [TorchLoader](doc/torch-loader.md)
 - [Resume and Checkpointing](doc/resume.md)
 - [Distributed Loading](doc/distributed.md)
+- [Persistent Cache](doc/cache.md)
 - [Data Conventions](doc/data-conventions.md)
 
 ## Development

--- a/doc/cache.md
+++ b/doc/cache.md
@@ -1,0 +1,101 @@
+# Persistent Cache
+
+`mvp-dataset` stores all derived data under one cache root. Set it independently on each node:
+
+```bash
+export MVP_DATASET_CACHE_DIR=/mnt/shared-cache/mvp-dataset
+```
+
+Different local mount paths may point to the same shared storage. Absolute source and cache paths are never included in
+cache fingerprints or persisted manifests.
+
+This cache has no legacy-path discovery or migration. Existing source-adjacent cache directories are ignored.
+
+## Layout
+
+```text
+<cache-root>/
+  <source-fingerprint>/
+    source.json
+    jsonl-split-v1/
+      <artifact-fingerprint>/
+        manifest.json
+        complete
+        ...
+    lance-ref-index-v1/
+      <artifact-fingerprint>/
+        manifest.json
+        complete
+        ...
+    lance-filter-index-v1/
+      <artifact-fingerprint>/
+        manifest.json
+        complete
+        ...
+  _locks/
+  _tmp/
+```
+
+The first fingerprint identifies the source. The cache-kind directory identifies the artifact format. The final
+fingerprint covers cache parameters and dependent sources.
+
+Local file fingerprints use source-relative paths, sizes, and nanosecond modification times by default. To hash full
+file contents instead:
+
+```bash
+export MVP_DATASET_CACHE_FINGERPRINT_MODE=content
+```
+
+Supported values are `metadata` and `content`.
+
+## Builder API
+
+`CacheManager.ensure()` supports both complete-artifact and distributed part builders:
+
+```python
+entry = manager.ensure(..., build=build_artifact)
+
+entry = manager.ensure(
+    ...,
+    parts=plan_parts,
+    build=build_one_part,
+)
+```
+
+The presence of `parts` selects the callback signature: whole-artifact builds receive a temporary directory, while
+partitioned builds receive a part name and temporary directory. Both modes produce the same `CacheEntry` contract.
+Part builders automatically claim available work through per-part leases and continue with unfinished parts after
+completing their current part.
+
+## Crash and Concurrency Safety
+
+Builders never write into a final artifact directory. Each build uses a unique directory under `_tmp`, writes and
+validates all declared files, then writes `manifest.json` and `complete`. The completed directory is published with a
+same-filesystem atomic rename.
+
+An interrupted build therefore leaves only an ignored temporary directory. Build ownership uses advisory `flock`
+leases on stable files under `_locks`; lock files are never deleted or replaced. The kernel releases a lease when its
+process exits, including `SIGKILL`, and the next owner removes abandoned temporary directories before rebuilding.
+Shared cache filesystems must provide cross-host POSIX advisory lock semantics.
+
+Concurrent builders for the same key share one completed result. A cache entry is usable only when its fingerprints,
+manifest, completion marker, declared files, and file sizes all validate.
+
+Artifacts such as Lance filter indexes use partitioned builds. Concurrent ranks and workers claim independent parts,
+write them through part-specific temporary directories, and publish each part under its own advisory file lease. Parts
+completed before a process failure remain reusable, while abandoned part temporary directories are replaced by the
+next owner. A generation ID fences off workers from abandoned attempts, and the finalizer locks and validates every
+part before atomically publishing the complete artifact.
+
+## Management API
+
+```python
+from mvp_dataset import clear_cache, list_cache_entries
+
+entries = list_cache_entries()
+removed = clear_cache(kind="jsonl-split")
+removed = clear_cache(source_fingerprint="...")
+```
+
+Both functions accept an optional cache root as their first argument. `clear_cache()` only removes completed artifacts;
+it does not modify source data.

--- a/doc/data-conventions.md
+++ b/doc/data-conventions.md
@@ -98,5 +98,7 @@ Runtime context may read common distributed environment variables when explicit 
 
 Source behavior variables:
 
+- `MVP_DATASET_CACHE_DIR`: root for all persistent cache artifacts.
+- `MVP_DATASET_CACHE_FINGERPRINT_MODE`: `metadata` (default) or `content` for local source fingerprints.
 - `LOADER_TAR_KEY_DOT_LEVEL`: tar key parsing level, default `1`.
 - `MVP_DATASET_TAR_MAX_OPEN_FILES`: maximum cached tar file handles used while resolving JSONL tar references.

--- a/doc/dataset-api.md
+++ b/doc/dataset-api.md
@@ -33,7 +33,6 @@ Source-specific arguments are documented in [Source Formats](source-formats.md).
 ```python
 dataset = Dataset.from_source("lance", "/data/train.lance").filter(
     "score >= 0.8 AND label IS NOT NULL",
-    index={"scope": "shared"},
 )
 ```
 
@@ -56,11 +55,8 @@ Overlapping predicate results are deduplicated and source order is preserved. Re
 with `AND`, so `filter([p1, p2]).filter(q)` means `(p1 AND q) OR (p2 AND q)`. A Lance scalar index on the ID column is
 recommended because each predicate is a separate query.
 
-The optional index scope controls how the disk-backed filtered-row index is built:
-
-- `"process"`: the current process prepares all missing parts.
-- `"node_local"`: local ranks build parts together; the cache must be visible within the node.
-- `"shared"` (default): all ranks build parts together; the cache must be visible across nodes.
+The disk-backed filtered-row index uses the unified persistent cache. Concurrent ranks and workers using the same
+cache root cooperatively build independent fragment parts and share the completed index.
 
 `filter(...).split(...)` and `filter(...).sample(...)` operate on the filtered row space. Lance source shuffle modes
 `none`, `global`, and `chunk` remain supported.
@@ -160,8 +156,8 @@ Selection granularity depends on what the source can read efficiently:
   and `sample(f)` keeps exactly `round(f * num_rows)` rows, reading only those rows.
 - **parquet** — chunk-level, weighted by row count.
 - **tar** / **jsonl** — whole-shard level. Fractions are approximate and bounded
-  by the shard/file count; a single tar or `.jsonl` file is one shard and cannot
-  be split internally.
+  by the prepared shard count. JSONL files may be split into cached logical shards
+  to satisfy the runtime slot count; tar files are not split internally.
 
 A subset must keep at least `context.total_slots` units (shards/chunks) for
 unit-based sources, otherwise a `ValueError` is raised. `split`/`sample` cannot

--- a/doc/index.md
+++ b/doc/index.md
@@ -10,4 +10,5 @@ Use this directory for detailed `mvp-dataset` usage and API notes.
 - [TorchLoader](torch-loader.md): PyTorch DataLoader integration and loader-side stages.
 - [Resume and Checkpointing](resume.md): iterator checkpointing, compatibility checks, and restore patterns.
 - [Distributed Loading](distributed.md): runtime context, mesh semantics, sharding, and seeds.
+- [Persistent Cache](cache.md): unified paths, fingerprints, crash recovery, and management APIs.
 - [Data Conventions](data-conventions.md): sample metadata, tar member naming, JSONL references, and environment variables.

--- a/doc/source-formats.md
+++ b/doc/source-formats.md
@@ -50,6 +50,8 @@ JSONL source notes:
 
 - Inputs must end with `.jsonl`.
 - Files are split into slot-aligned logical shards.
+- Cached split files keep the original source-relative file and line identity, so sample keys and resume fingerprints do
+  not depend on the cache root or source mount prefix.
 - Samples are JSON objects represented as Python dictionaries.
 
 ## Parquet
@@ -116,10 +118,8 @@ Lance source notes:
 - `dataset.filter(predicate)` accepts a Lance SQL WHERE expression or a sequence of expressions. Sequence entries are
   OR-combined logically and executed as independent native filtered scans, which supports bounded ID `IN (...)`
   batches. Matching rows are deduplicated in source order and stored in a disk-backed row index.
-- Filter indexes are split into deterministic fragment parts and memory-mapped at runtime. Set
-  `MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR` when the Lance source is remote or read-only.
-- Select filter index scope with `index={"scope": "process" | "node_local" | "shared"}`. The default is `"shared"`;
-  storage visibility is not detected automatically.
+- Filter indexes are split into deterministic fragment parts, built cooperatively by concurrent ranks and workers,
+  memory-mapped at runtime, and stored under the unified `MVP_DATASET_CACHE_DIR` root.
 - Filtering Lance datasets with deleted rows is not supported.
 - Lance reference columns can be resolved with `resolve_ref(...)`.
 - Use `chunk_shuffle={"chunk_size": 65536, "k": 4, "row_order": "sequential"}` to tune chunk shuffle.
@@ -144,7 +144,6 @@ dataset = dataset.resolve_ref(
     ["image"],
     resolve_batch_size=1024,
     index={
-        "scope": "shared",
         "build_strategy": "auto",
         "bucket_count": 4096,
     },
@@ -154,11 +153,9 @@ dataset = dataset.resolve_ref(
 `resolve_ref(...)` appends a stateful assembly stage that resolves configured reference values lazily.
 The `index` dict supports:
 
-- `scope`: `"shared"` (default), `"node_local"`, or `"process"`.
 - `build_strategy`: `"auto"` (default), `"in_memory"`, or `"bucketed"`.
 - `bucket_count`: positive integer for `"bucketed"` builds. Defaults to `4096`.
 
 With `build_strategy="auto"`, small sources use the in-memory builder, while larger sources use a bucketed on-disk
 join to avoid keeping all reference keys in memory.
-By default, index cache files are stored under the main Lance dataset. Set
-`MVP_DATASET_LANCE_REF_INDEX_CACHE_DIR` to place them in another directory.
+Filter and reference indexes use the unified persistent cache described in [Persistent Cache](cache.md).

--- a/src/mvp_dataset/__init__.py
+++ b/src/mvp_dataset/__init__.py
@@ -1,5 +1,6 @@
 """Public package interface for mvp-dataset."""
 
+from .cache import CacheConfig, CacheEntryInfo, clear_cache, list_cache_entries
 from .core import (
     Consumer,
     DataLoadMesh,
@@ -20,6 +21,8 @@ from .log import (
 
 __all__ = [
     "DataLoadMesh",
+    "CacheConfig",
+    "CacheEntryInfo",
     "Consumer",
     "Dataset",
     "ResumeStateError",
@@ -28,6 +31,8 @@ __all__ = [
     "UnsupportedResume",
     "get_log_level",
     "get_logger",
+    "clear_cache",
+    "list_cache_entries",
     "reset_log_level",
     "reset_logger",
     "set_log_level",

--- a/src/mvp_dataset/cache/__init__.py
+++ b/src/mvp_dataset/cache/__init__.py
@@ -1,0 +1,58 @@
+"""Unified persistent cache management."""
+
+from pathlib import Path
+
+from .config import (
+    CACHE_DIR_ENV,
+    CACHE_FINGERPRINT_MODE_ENV,
+    CacheConfig,
+    FingerprintMode,
+)
+from .fingerprint import (
+    SourceFingerprint,
+    fingerprint_local_files,
+    fingerprint_payload,
+    fingerprint_source_manifest,
+)
+from .manager import (
+    CacheBuildResult,
+    CacheEntry,
+    CacheEntryInfo,
+    CacheKey,
+    CacheManager,
+)
+
+
+def list_cache_entries(cache_dir: str | Path | None = None) -> tuple[CacheEntryInfo, ...]:
+    """List completed cache entries under an explicit or resolved root."""
+    return CacheManager(CacheConfig.resolve(cache_dir)).list_entries()
+
+
+def clear_cache(
+    cache_dir: str | Path | None = None,
+    *,
+    source_fingerprint: str | None = None,
+    kind: str | None = None,
+) -> int:
+    """Remove completed cache entries matching the optional filters."""
+    manager = CacheManager(CacheConfig.resolve(cache_dir))
+    return manager.clear(source_fingerprint=source_fingerprint, kind=kind)
+
+
+__all__ = [
+    "CACHE_DIR_ENV",
+    "CACHE_FINGERPRINT_MODE_ENV",
+    "CacheBuildResult",
+    "CacheConfig",
+    "CacheEntry",
+    "CacheEntryInfo",
+    "CacheKey",
+    "CacheManager",
+    "FingerprintMode",
+    "SourceFingerprint",
+    "fingerprint_local_files",
+    "fingerprint_payload",
+    "fingerprint_source_manifest",
+    "clear_cache",
+    "list_cache_entries",
+]

--- a/src/mvp_dataset/cache/config.py
+++ b/src/mvp_dataset/cache/config.py
@@ -1,0 +1,54 @@
+"""Unified cache configuration."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+CACHE_DIR_ENV = "MVP_DATASET_CACHE_DIR"
+CACHE_FINGERPRINT_MODE_ENV = "MVP_DATASET_CACHE_FINGERPRINT_MODE"
+FingerprintMode = Literal["metadata", "content"]
+
+
+@dataclass(frozen=True, slots=True)
+class CacheConfig:
+    """Configuration shared by all persistent cache artifacts."""
+
+    root: Path
+    fingerprint_mode: FingerprintMode = "metadata"
+    wait_timeout_seconds: float = 30 * 60
+    poll_interval_seconds: float = 0.25
+
+    def __post_init__(self) -> None:
+        """Validate and normalize the configuration."""
+        object.__setattr__(self, "root", Path(os.path.abspath(Path(self.root).expanduser())))
+        if self.fingerprint_mode not in ("metadata", "content"):
+            msg = f"[InvalidCacheFingerprintMode] mode={self.fingerprint_mode!r}"
+            raise ValueError(msg)
+        if self.wait_timeout_seconds <= 0:
+            msg = "[InvalidCacheWaitTimeout] wait_timeout_seconds must be > 0"
+            raise ValueError(msg)
+        if self.poll_interval_seconds <= 0:
+            msg = "[InvalidCachePollInterval] poll_interval_seconds must be > 0"
+            raise ValueError(msg)
+
+    @classmethod
+    def resolve(
+        cls,
+        cache_dir: str | Path | None = None,
+        *,
+        fingerprint_mode: FingerprintMode | None = None,
+    ) -> CacheConfig:
+        """Resolve an explicit, environment, or platform-default cache root."""
+        if cache_dir is not None:
+            root = Path(cache_dir)
+        elif raw_root := os.environ.get(CACHE_DIR_ENV):
+            root = Path(raw_root)
+        elif xdg_cache_home := os.environ.get("XDG_CACHE_HOME"):
+            root = Path(xdg_cache_home) / "mvp-dataset"
+        else:
+            root = Path.home() / ".cache" / "mvp-dataset"
+        resolved_mode = fingerprint_mode or os.environ.get(CACHE_FINGERPRINT_MODE_ENV, "metadata")
+        return cls(root=root, fingerprint_mode=resolved_mode)

--- a/src/mvp_dataset/cache/fingerprint.py
+++ b/src/mvp_dataset/cache/fingerprint.py
@@ -1,0 +1,105 @@
+"""Mount-independent cache fingerprint helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .config import FingerprintMode
+
+SOURCE_FINGERPRINT_SCHEMA_VERSION = 1
+_CONTENT_HASH_CHUNK_SIZE = 1024 * 1024
+
+
+@dataclass(frozen=True, slots=True, init=False)
+class SourceFingerprint:
+    """A stable source digest and the manifest used to produce it."""
+
+    value: str
+    _manifest_bytes: bytes = field(repr=False)
+
+    def __init__(self, *, value: str, manifest: Mapping[str, Any]) -> None:
+        """Store an immutable canonical manifest and verify its digest."""
+        manifest_bytes = canonical_json_bytes(dict(manifest))
+        expected = hashlib.sha256(manifest_bytes).hexdigest()
+        if value != expected:
+            msg = f"[InvalidSourceFingerprint] expected={expected} got={value}"
+            raise ValueError(msg)
+        object.__setattr__(self, "value", value)
+        object.__setattr__(self, "_manifest_bytes", manifest_bytes)
+
+    @property
+    def manifest(self) -> dict[str, Any]:
+        """Return a detached copy of the canonical source manifest."""
+        manifest = json.loads(self._manifest_bytes)
+        if not isinstance(manifest, dict):
+            msg = "[InvalidSourceManifest] expected object"
+            raise RuntimeError(msg)
+        return manifest
+
+
+def canonical_json_bytes(value: object) -> bytes:
+    """Serialize a JSON-compatible value deterministically."""
+    return json.dumps(value, allow_nan=False, ensure_ascii=True, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def fingerprint_payload(value: object) -> str:
+    """Return a SHA-256 fingerprint for a JSON-compatible value."""
+    return hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+
+
+def fingerprint_source_manifest(manifest: Mapping[str, Any]) -> SourceFingerprint:
+    """Return a source fingerprint from a mount-independent manifest."""
+    normalized = json.loads(canonical_json_bytes(dict(manifest)))
+    return SourceFingerprint(value=fingerprint_payload(normalized), manifest=normalized)
+
+
+def fingerprint_local_files(
+    paths: Sequence[str | os.PathLike[str]],
+    *,
+    mode: FingerprintMode = "metadata",
+) -> SourceFingerprint:
+    """Fingerprint local files without including their absolute mount prefix."""
+    if not paths:
+        msg = "[EmptyCacheSource] at least one source file is required"
+        raise ValueError(msg)
+    if mode not in ("metadata", "content"):
+        msg = f"[InvalidCacheFingerprintMode] mode={mode!r}"
+        raise ValueError(msg)
+
+    absolute_paths = [Path(os.path.abspath(Path(path).expanduser())) for path in paths]
+    common_root = Path(os.path.commonpath([str(path.parent) for path in absolute_paths]))
+    files: list[dict[str, object]] = []
+    for path in absolute_paths:
+        stat = path.stat()
+        item: dict[str, object] = {
+            "path": path.relative_to(common_root).as_posix(),
+            "size": stat.st_size,
+        }
+        if mode == "metadata":
+            item["mtime_ns"] = stat.st_mtime_ns
+        else:
+            item["sha256"] = _hash_file(path)
+        files.append(item)
+
+    return fingerprint_source_manifest(
+        {
+            "schema_version": SOURCE_FINGERPRINT_SCHEMA_VERSION,
+            "kind": "local-files",
+            "fingerprint_mode": mode,
+            "files": files,
+        }
+    )
+
+
+def _hash_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(_CONTENT_HASH_CHUNK_SIZE):
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/src/mvp_dataset/cache/manager.py
+++ b/src/mvp_dataset/cache/manager.py
@@ -1,0 +1,868 @@
+"""Crash-safe persistent cache management."""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import re
+import shutil
+import socket
+import time
+import uuid
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, BinaryIO, cast, overload
+
+from .config import CacheConfig
+from .fingerprint import SourceFingerprint, canonical_json_bytes, fingerprint_payload
+
+CACHE_MANIFEST_SCHEMA_VERSION = 1
+CACHE_MANIFEST_NAME = "manifest.json"
+CACHE_COMPLETE_NAME = "complete"
+SOURCE_MANIFEST_NAME = "source.json"
+_CACHE_KIND_PATTERN = re.compile(r"^(?P<kind>[a-z][a-z0-9-]*)-v(?P<version>[1-9][0-9]*)$")
+_FINGERPRINT_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+_PARTITION_NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_PARTITION_SCHEMA_VERSION = 1
+_PARTITION_ACTIVE_NAME = "active.json"
+_PARTITION_JOIN_SECONDS = 0.1
+
+
+@dataclass(frozen=True, slots=True)
+class CacheBuildResult:
+    """Files and result metadata produced by one cache build."""
+
+    files: tuple[str, ...]
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_files(
+        cls,
+        files: Sequence[str],
+        *,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> CacheBuildResult:
+        """Build a normalized result from relative file paths."""
+        return cls(files=tuple(files), metadata=dict(metadata or {}))
+
+
+@dataclass(frozen=True, slots=True)
+class CacheKey:
+    """Complete identity for one cache artifact."""
+
+    source_fingerprint: str
+    kind: str
+    format_version: int
+    artifact_fingerprint: str
+    parameters: dict[str, Any]
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        source_fingerprint: str,
+        kind: str,
+        format_version: int,
+        parameters: Mapping[str, Any],
+    ) -> CacheKey:
+        """Create and validate a cache key."""
+        if not _FINGERPRINT_PATTERN.fullmatch(source_fingerprint):
+            msg = f"[InvalidSourceFingerprint] value={source_fingerprint!r}"
+            raise ValueError(msg)
+        if not re.fullmatch(r"[a-z][a-z0-9-]*", kind):
+            msg = f"[InvalidCacheKind] kind={kind!r}"
+            raise ValueError(msg)
+        if isinstance(format_version, bool) or not isinstance(format_version, int) or format_version <= 0:
+            msg = f"[InvalidCacheFormatVersion] expected a positive integer, got={format_version!r}"
+            raise ValueError(msg)
+        normalized_parameters = json.loads(canonical_json_bytes(dict(parameters)))
+        artifact_fingerprint = fingerprint_payload(
+            {
+                "kind": kind,
+                "format_version": format_version,
+                "parameters": normalized_parameters,
+            }
+        )
+        return cls(
+            source_fingerprint=source_fingerprint,
+            kind=kind,
+            format_version=format_version,
+            artifact_fingerprint=artifact_fingerprint,
+            parameters=normalized_parameters,
+        )
+
+    @property
+    def kind_directory(self) -> str:
+        """Return the versioned cache-kind directory name."""
+        return f"{self.kind}-v{self.format_version}"
+
+
+@dataclass(frozen=True, slots=True)
+class CacheEntry:
+    """Resolved paths for one cache artifact."""
+
+    key: CacheKey
+    path: Path
+    lock_path: Path
+    temporary_parent: Path
+
+    @property
+    def manifest_path(self) -> Path:
+        """Return the artifact manifest path."""
+        return self.path / CACHE_MANIFEST_NAME
+
+    @property
+    def complete_path(self) -> Path:
+        """Return the artifact completion marker path."""
+        return self.path / CACHE_COMPLETE_NAME
+
+    def read_manifest(self) -> dict[str, Any]:
+        """Read the completed artifact manifest."""
+        with self.manifest_path.open(encoding="utf-8") as handle:
+            payload = json.load(handle)
+        if not isinstance(payload, dict):
+            msg = f"[InvalidCacheManifest] expected object at {self.manifest_path}"
+            raise RuntimeError(msg)
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class CacheEntryInfo:
+    """Summary of one completed cache artifact."""
+
+    source_fingerprint: str
+    kind: str
+    format_version: int
+    artifact_fingerprint: str
+    path: Path
+    size_bytes: int
+
+
+@dataclass(frozen=True, slots=True)
+class _PartitionAttempt:
+    generation: str
+    created_ns: int
+    parts: tuple[str, ...]
+    root: Path
+
+    @property
+    def payload_path(self) -> Path:
+        return self.root / "payload"
+
+    @property
+    def results_path(self) -> Path:
+        return self.root / "results"
+
+    @property
+    def locks_path(self) -> Path:
+        return self.root / "locks"
+
+    @property
+    def temporary_path(self) -> Path:
+        return self.root / "tmp"
+
+
+@dataclass(slots=True)
+class _FileLease:
+    """An advisory file lock owned through one open file description."""
+
+    lease_id: str
+    path: Path
+    handle: BinaryIO = field(repr=False)
+    released: bool = False
+
+    @property
+    def is_held(self) -> bool:
+        """Return whether this process still owns the lease handle."""
+        return not self.released and not self.handle.closed
+
+
+class CacheManager:
+    """Manage cache paths, validation, concurrent builds, and atomic publication."""
+
+    def __init__(self, config: CacheConfig | None = None) -> None:
+        """Initialize the manager from explicit or resolved configuration."""
+        self.config = CacheConfig.resolve() if config is None else config
+        self.root = self.config.root
+
+    def entry(self, key: CacheKey) -> CacheEntry:
+        """Resolve all paths for a cache key."""
+        artifact_path = self.root / key.source_fingerprint / key.kind_directory / key.artifact_fingerprint
+        lock_path = (
+            self.root / "_locks" / key.source_fingerprint / key.kind_directory / (f"{key.artifact_fingerprint}.lock")
+        )
+        temporary_parent = self.root / "_tmp" / key.source_fingerprint / key.kind_directory / (key.artifact_fingerprint)
+        return CacheEntry(key=key, path=artifact_path, lock_path=lock_path, temporary_parent=temporary_parent)
+
+    @overload
+    def ensure(
+        self,
+        *,
+        source: SourceFingerprint,
+        kind: str,
+        format_version: int,
+        parameters: Mapping[str, Any],
+        build: Callable[[Path], CacheBuildResult],
+        parts: None = None,
+    ) -> CacheEntry: ...
+
+    @overload
+    def ensure(
+        self,
+        *,
+        source: SourceFingerprint,
+        kind: str,
+        format_version: int,
+        parameters: Mapping[str, Any],
+        build: Callable[[str, Path], CacheBuildResult],
+        parts: Callable[[], Sequence[str]],
+    ) -> CacheEntry: ...
+
+    def ensure(
+        self,
+        *,
+        source: SourceFingerprint,
+        kind: str,
+        format_version: int,
+        parameters: Mapping[str, Any],
+        build: Callable[[Path], CacheBuildResult] | Callable[[str, Path], CacheBuildResult],
+        parts: Callable[[], Sequence[str]] | None = None,
+    ) -> CacheEntry:
+        """Return a valid entry using either one builder or distributed part builders."""
+        key = CacheKey.create(
+            source_fingerprint=source.value,
+            kind=kind,
+            format_version=format_version,
+            parameters=parameters,
+        )
+        entry = self.entry(key)
+        self._ensure_source_manifest(source)
+        if parts is not None:
+            return self._ensure_partitioned_entry(
+                entry,
+                parts=parts,
+                build=cast(Callable[[str, Path], CacheBuildResult], build),
+            )
+
+        artifact_build = cast(Callable[[Path], CacheBuildResult], build)
+
+        deadline = time.monotonic() + self.config.wait_timeout_seconds
+
+        while True:
+            if self.is_valid(entry):
+                return entry
+            lease = self._acquire_lock(entry)
+            if lease is not None:
+                try:
+                    if self.is_valid(entry):
+                        return entry
+                    return self._build_entry(entry, artifact_build, lease)
+                finally:
+                    self._release_lock(lease)
+            if time.monotonic() >= deadline:
+                msg = f"[CacheBuildTimeout] timed out waiting for {entry.path}"
+                raise TimeoutError(msg)
+            time.sleep(self.config.poll_interval_seconds)
+
+    def _ensure_partitioned_entry(
+        self,
+        entry: CacheEntry,
+        *,
+        parts: Callable[[], Sequence[str]],
+        build: Callable[[str, Path], CacheBuildResult],
+    ) -> CacheEntry:
+        if self.is_valid(entry):
+            return entry
+
+        partition_names = self._normalize_partition_names(parts())
+        deadline = time.monotonic() + self.config.wait_timeout_seconds
+
+        while True:
+            if self.is_valid(entry):
+                return entry
+            attempt = self._ensure_partition_attempt(entry, partition_names, deadline)
+            if attempt is None:
+                return entry
+            completed = self._run_partition_attempt(
+                entry,
+                attempt,
+                partition_names,
+                build,
+                deadline,
+            )
+            if completed is not None:
+                return completed
+
+    def is_valid(self, entry: CacheEntry) -> bool:
+        """Return whether an entry is complete and matches its expected key."""
+        if not entry.complete_path.is_file() or not entry.manifest_path.is_file():
+            return False
+        try:
+            manifest = entry.read_manifest()
+        except (OSError, json.JSONDecodeError, RuntimeError):
+            return False
+        key = entry.key
+        if manifest.get("schema_version") != CACHE_MANIFEST_SCHEMA_VERSION:
+            return False
+        if manifest.get("source_fingerprint") != key.source_fingerprint:
+            return False
+        if manifest.get("kind") != key.kind or manifest.get("format_version") != key.format_version:
+            return False
+        if manifest.get("artifact_fingerprint") != key.artifact_fingerprint:
+            return False
+        if manifest.get("parameters") != key.parameters:
+            return False
+        files = manifest.get("files")
+        if not isinstance(files, list):
+            return False
+        return all(self._manifest_file_is_valid(entry.path, item) for item in files)
+
+    def list_entries(self) -> tuple[CacheEntryInfo, ...]:
+        """Return completed cache entries under the configured root."""
+        if not self.root.is_dir():
+            return ()
+        entries: list[CacheEntryInfo] = []
+        for source_dir in sorted(self.root.iterdir()):
+            if not source_dir.is_dir() or source_dir.name.startswith("_"):
+                continue
+            for kind_dir in sorted(source_dir.iterdir()):
+                match = _CACHE_KIND_PATTERN.fullmatch(kind_dir.name)
+                if not kind_dir.is_dir() or match is None:
+                    continue
+                for artifact_dir in sorted(kind_dir.iterdir()):
+                    if not artifact_dir.is_dir() or not _FINGERPRINT_PATTERN.fullmatch(artifact_dir.name):
+                        continue
+                    manifest_path = artifact_dir / CACHE_MANIFEST_NAME
+                    complete_path = artifact_dir / CACHE_COMPLETE_NAME
+                    if not manifest_path.is_file() or not complete_path.is_file():
+                        continue
+                    entries.append(
+                        CacheEntryInfo(
+                            source_fingerprint=source_dir.name,
+                            kind=match.group("kind"),
+                            format_version=int(match.group("version")),
+                            artifact_fingerprint=artifact_dir.name,
+                            path=artifact_dir,
+                            size_bytes=sum(path.stat().st_size for path in artifact_dir.rglob("*") if path.is_file()),
+                        )
+                    )
+        return tuple(entries)
+
+    def clear(
+        self,
+        *,
+        source_fingerprint: str | None = None,
+        kind: str | None = None,
+    ) -> int:
+        """Remove matching completed cache entries and return the removal count."""
+        removed = 0
+        for info in self.list_entries():
+            if source_fingerprint is not None and info.source_fingerprint != source_fingerprint:
+                continue
+            if kind is not None and info.kind != kind:
+                continue
+            self._remove_path(info.path)
+            removed += 1
+        return removed
+
+    def _ensure_source_manifest(self, source: SourceFingerprint) -> None:
+        source_manifest = source.manifest
+        if fingerprint_payload(source_manifest) != source.value:
+            msg = f"[InvalidSourceFingerprint] value={source.value}"
+            raise ValueError(msg)
+        source_dir = self.root / source.value
+        source_dir.mkdir(parents=True, exist_ok=True)
+        destination = source_dir / SOURCE_MANIFEST_NAME
+        payload = {
+            "schema_version": CACHE_MANIFEST_SCHEMA_VERSION,
+            "source_fingerprint": source.value,
+            "source": source_manifest,
+        }
+        if destination.is_file():
+            try:
+                existing = json.loads(destination.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                existing = None
+            if existing == payload:
+                return
+            if existing is not None:
+                msg = f"[CacheSourceFingerprintCollision] conflicting source manifest at {destination}"
+                raise RuntimeError(msg)
+            destination.unlink(missing_ok=True)
+        temporary = source_dir / f".{SOURCE_MANIFEST_NAME}.{uuid.uuid4().hex}.tmp"
+        temporary.write_bytes(canonical_json_bytes(payload) + b"\n")
+        try:
+            temporary.replace(destination)
+        except OSError:
+            if not destination.is_file():
+                raise
+        finally:
+            temporary.unlink(missing_ok=True)
+
+    def _acquire_lock(self, entry: CacheEntry) -> _FileLease | None:
+        return self._acquire_path_lock(entry.lock_path)
+
+    @staticmethod
+    def _acquire_path_lock(lock_path: Path) -> _FileLease | None:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        handle = lock_path.open("a+b")
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            handle.close()
+            return None
+        lease_id = uuid.uuid4().hex
+        try:
+            owner = {
+                "hostname": socket.gethostname(),
+                "pid": os.getpid(),
+                "created_ns": time.time_ns(),
+                "lease_id": lease_id,
+            }
+            handle.seek(0)
+            handle.truncate()
+            handle.write(canonical_json_bytes(owner) + b"\n")
+            handle.flush()
+        except Exception:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            handle.close()
+            raise
+        return _FileLease(lease_id=lease_id, path=lock_path, handle=handle)
+
+    @staticmethod
+    def _release_lock(lease: _FileLease) -> None:
+        CacheManager._release_path_lock(lease)
+
+    @staticmethod
+    def _release_path_lock(lease: _FileLease) -> None:
+        if not lease.is_held:
+            return
+        try:
+            fcntl.flock(lease.handle.fileno(), fcntl.LOCK_UN)
+        finally:
+            lease.released = True
+            lease.handle.close()
+
+    @staticmethod
+    def _lock_is_owned(entry: CacheEntry, lease: _FileLease) -> bool:
+        return entry.lock_path == lease.path and lease.is_held
+
+    @staticmethod
+    def _path_lock_is_owned(lock_path: Path, lease: _FileLease) -> bool:
+        return lock_path == lease.path and lease.is_held
+
+    @staticmethod
+    def _normalize_partition_names(raw_parts: Sequence[str]) -> tuple[str, ...]:
+        parts = tuple(raw_parts)
+        for part in parts:
+            if (
+                not isinstance(part, str)
+                or not _PARTITION_NAME_PATTERN.fullmatch(part)
+                or part in {CACHE_MANIFEST_NAME, CACHE_COMPLETE_NAME}
+            ):
+                msg = f"[InvalidCachePartName] part={part!r}"
+                raise ValueError(msg)
+        if len(set(parts)) != len(parts):
+            msg = "[DuplicateCachePartName] cache part names must be unique"
+            raise ValueError(msg)
+        return parts
+
+    def _ensure_partition_attempt(
+        self,
+        entry: CacheEntry,
+        parts: tuple[str, ...],
+        deadline: float,
+    ) -> _PartitionAttempt | None:
+        while True:
+            if self.is_valid(entry):
+                return None
+            lease = self._acquire_lock(entry)
+            if lease is not None:
+                try:
+                    if self.is_valid(entry):
+                        return None
+                    self._discard_invalid_entry(entry)
+                    attempt = self._read_partition_attempt(entry, parts)
+                    return attempt if attempt is not None else self._create_partition_attempt(entry, parts)
+                finally:
+                    self._release_lock(lease)
+            if time.monotonic() >= deadline:
+                msg = f"[CacheBuildTimeout] timed out initializing partitioned build for {entry.path}"
+                raise TimeoutError(msg)
+            time.sleep(min(self.config.poll_interval_seconds, 0.01))
+
+    def _read_partition_attempt(
+        self,
+        entry: CacheEntry,
+        expected_parts: tuple[str, ...],
+    ) -> _PartitionAttempt | None:
+        active_path = entry.temporary_parent / _PARTITION_ACTIVE_NAME
+        try:
+            active = json.loads(active_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        if not isinstance(active, dict) or active.get("schema_version") != _PARTITION_SCHEMA_VERSION:
+            return None
+        generation = active.get("generation")
+        created_ns = active.get("created_ns")
+        raw_parts = active.get("parts")
+        if not isinstance(generation, str) or not re.fullmatch(r"[0-9a-f]{32}", generation):
+            return None
+        if not isinstance(created_ns, int):
+            return None
+        if not isinstance(raw_parts, list) or not all(isinstance(part, str) for part in raw_parts):
+            return None
+        if tuple(raw_parts) != expected_parts:
+            msg = f"[CachePartitionPlanMismatch] active plan differs for {entry.path}"
+            raise RuntimeError(msg)
+        attempt = _PartitionAttempt(
+            generation=generation,
+            created_ns=created_ns,
+            parts=expected_parts,
+            root=entry.temporary_parent / f"partition-{generation}",
+        )
+        required_paths = (
+            attempt.payload_path,
+            attempt.results_path,
+            attempt.locks_path,
+            attempt.temporary_path,
+        )
+        return attempt if all(path.is_dir() for path in required_paths) else None
+
+    def _create_partition_attempt(
+        self,
+        entry: CacheEntry,
+        parts: tuple[str, ...],
+    ) -> _PartitionAttempt:
+        entry.temporary_parent.mkdir(parents=True, exist_ok=True)
+        generation = uuid.uuid4().hex
+        created_ns = time.time_ns()
+        attempt = _PartitionAttempt(
+            generation=generation,
+            created_ns=created_ns,
+            parts=parts,
+            root=entry.temporary_parent / f"partition-{generation}",
+        )
+        for path in (
+            attempt.payload_path,
+            attempt.results_path,
+            attempt.locks_path,
+            attempt.temporary_path,
+        ):
+            path.mkdir(parents=True, exist_ok=False)
+        active = {
+            "schema_version": _PARTITION_SCHEMA_VERSION,
+            "generation": generation,
+            "created_ns": created_ns,
+            "parts": list(parts),
+        }
+        self._write_json_atomic(entry.temporary_parent / _PARTITION_ACTIVE_NAME, active)
+        for path in entry.temporary_parent.glob("partition-*"):
+            if path != attempt.root:
+                self._remove_path(path)
+        return attempt
+
+    def _run_partition_attempt(
+        self,
+        entry: CacheEntry,
+        attempt: _PartitionAttempt,
+        ordered_parts: tuple[str, ...],
+        build: Callable[[str, Path], CacheBuildResult],
+        deadline: float,
+    ) -> CacheEntry | None:
+        join_remaining = attempt.created_ns / 1_000_000_000 + _PARTITION_JOIN_SECONDS - time.time()
+        if join_remaining > 0:
+            time.sleep(join_remaining)
+        while True:
+            if self.is_valid(entry):
+                return entry
+            if not self._partition_attempt_is_active(entry, attempt):
+                return None
+
+            results = tuple(self._read_partition_result(attempt, part) for part in attempt.parts)
+            if all(result is not None for result in results):
+                completed = self._publish_partition_attempt(entry, attempt)
+                if completed is not None:
+                    return completed
+
+            made_progress = False
+            for part in ordered_parts:
+                if self._read_partition_result(attempt, part) is not None:
+                    continue
+                lock_path = attempt.locks_path / f"{part}.lock"
+                lease = self._acquire_path_lock(lock_path)
+                if lease is not None:
+                    try:
+                        if (
+                            not self.is_valid(entry)
+                            and self._partition_attempt_is_active(entry, attempt)
+                            and self._read_partition_result(attempt, part) is None
+                        ):
+                            self._build_partition_part(entry, attempt, part, build, lease)
+                    finally:
+                        self._release_path_lock(lease)
+                    made_progress = True
+                    break
+            if made_progress:
+                continue
+            if time.monotonic() >= deadline:
+                msg = f"[CacheBuildTimeout] timed out waiting for partitioned build at {entry.path}"
+                raise TimeoutError(msg)
+            time.sleep(self.config.poll_interval_seconds)
+
+    def _build_partition_part(
+        self,
+        entry: CacheEntry,
+        attempt: _PartitionAttempt,
+        part: str,
+        build: Callable[[str, Path], CacheBuildResult],
+        lease: _FileLease,
+    ) -> None:
+        result_path = attempt.results_path / f"{part}.json"
+        destination = attempt.payload_path / part
+        result_path.unlink(missing_ok=True)
+        self._remove_path(destination)
+        temporary_parent = attempt.temporary_path / part
+        temporary_parent.mkdir(parents=True, exist_ok=True)
+        for path in temporary_parent.iterdir():
+            self._remove_path(path)
+        temporary = temporary_parent / f"{socket.gethostname()}-{os.getpid()}-{uuid.uuid4().hex}"
+        temporary.mkdir()
+        try:
+            result = build(part, temporary)
+            files = self._validate_build_result(temporary, result)
+            result_payload = {
+                "schema_version": _PARTITION_SCHEMA_VERSION,
+                "part": part,
+                "metadata": json.loads(canonical_json_bytes(result.metadata)),
+                "files": files,
+            }
+            if not self._partition_attempt_is_active(entry, attempt):
+                msg = f"[CachePartGenerationLost] active generation changed for {entry.path}"
+                raise RuntimeError(msg)
+            if not self._path_lock_is_owned(lease.path, lease):
+                msg = f"[CachePartLeaseLost] build lease was released for part {part!r}"
+                raise RuntimeError(msg)
+            temporary.replace(destination)
+            self._write_json_atomic(result_path, result_payload)
+        finally:
+            self._remove_path(temporary)
+
+    def _read_partition_result(self, attempt: _PartitionAttempt, part: str) -> dict[str, Any] | None:
+        result_path = attempt.results_path / f"{part}.json"
+        try:
+            result = json.loads(result_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        if not isinstance(result, dict) or result.get("schema_version") != _PARTITION_SCHEMA_VERSION:
+            return None
+        if result.get("part") != part or not isinstance(result.get("metadata"), dict):
+            return None
+        files = result.get("files")
+        if not isinstance(files, list):
+            return None
+        part_root = attempt.payload_path / part
+        if not all(self._manifest_file_is_valid(part_root, item) for item in files):
+            return None
+        return result
+
+    def _publish_partition_attempt(
+        self,
+        entry: CacheEntry,
+        attempt: _PartitionAttempt,
+    ) -> CacheEntry | None:
+        lease = self._acquire_lock(entry)
+        if lease is None:
+            return None
+        part_leases: list[_FileLease] = []
+        remove_temporary_parent = False
+        try:
+            if self.is_valid(entry):
+                return entry
+            if not self._partition_attempt_is_active(entry, attempt):
+                return None
+            for part in attempt.parts:
+                lock_path = attempt.locks_path / f"{part}.lock"
+                part_lease = self._acquire_path_lock(lock_path)
+                if part_lease is None:
+                    return None
+                part_leases.append(part_lease)
+            results = tuple(self._read_partition_result(attempt, part) for part in attempt.parts)
+            if any(result is None for result in results):
+                return None
+
+            files: list[dict[str, object]] = []
+            part_metadata: list[dict[str, object]] = []
+            for part, result in zip(attempt.parts, results, strict=True):
+                assert result is not None
+                part_files = []
+                for item in result["files"]:
+                    relative_path = f"{part}/{item['path']}"
+                    files.append({"path": relative_path, "size": item["size"]})
+                    part_files.append(relative_path)
+                part_metadata.append(
+                    {
+                        "name": part,
+                        "files": part_files,
+                        "metadata": result["metadata"],
+                    }
+                )
+            manifest = {
+                "schema_version": CACHE_MANIFEST_SCHEMA_VERSION,
+                "source_fingerprint": entry.key.source_fingerprint,
+                "kind": entry.key.kind,
+                "format_version": entry.key.format_version,
+                "artifact_fingerprint": entry.key.artifact_fingerprint,
+                "parameters": entry.key.parameters,
+                "metadata": {"parts": part_metadata},
+                "files": files,
+            }
+            (attempt.payload_path / CACHE_MANIFEST_NAME).write_bytes(canonical_json_bytes(manifest) + b"\n")
+            (attempt.payload_path / CACHE_COMPLETE_NAME).write_text("complete\n", encoding="utf-8")
+            if not self._partition_attempt_is_active(entry, attempt):
+                return None
+            if not self._lock_is_owned(entry, lease):
+                return None
+            self._discard_invalid_entry(entry)
+            entry.path.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                attempt.payload_path.replace(entry.path)
+            except OSError:
+                if not self.is_valid(entry):
+                    raise
+            if not self.is_valid(entry):
+                msg = f"[InvalidPublishedCache] cache publication failed validation at {entry.path}"
+                raise RuntimeError(msg)
+            if self._partition_attempt_is_active(entry, attempt):
+                remove_temporary_parent = True
+            return entry
+        finally:
+            for part_lease in part_leases:
+                self._release_path_lock(part_lease)
+            self._release_lock(lease)
+            if remove_temporary_parent:
+                self._remove_path(entry.temporary_parent)
+
+    @staticmethod
+    def _partition_attempt_is_active(entry: CacheEntry, attempt: _PartitionAttempt) -> bool:
+        try:
+            active = json.loads((entry.temporary_parent / _PARTITION_ACTIVE_NAME).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return False
+        return isinstance(active, dict) and active.get("generation") == attempt.generation
+
+    @staticmethod
+    def _write_json_atomic(destination: Path, payload: Mapping[str, Any]) -> None:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        temporary = destination.with_name(f".{destination.name}.{uuid.uuid4().hex}.tmp")
+        temporary.write_bytes(canonical_json_bytes(dict(payload)) + b"\n")
+        try:
+            temporary.replace(destination)
+        finally:
+            temporary.unlink(missing_ok=True)
+
+    def _build_entry(
+        self,
+        entry: CacheEntry,
+        build: Callable[[Path], CacheBuildResult],
+        lease: _FileLease,
+    ) -> CacheEntry:
+        self._discard_invalid_entry(entry)
+        self._remove_temporary_directories(entry)
+        entry.temporary_parent.mkdir(parents=True, exist_ok=True)
+        temporary = entry.temporary_parent / f"{socket.gethostname()}-{os.getpid()}-{uuid.uuid4().hex}"
+        temporary.mkdir()
+        try:
+            result = build(temporary)
+            files = self._validate_build_result(temporary, result)
+            manifest = {
+                "schema_version": CACHE_MANIFEST_SCHEMA_VERSION,
+                "source_fingerprint": entry.key.source_fingerprint,
+                "kind": entry.key.kind,
+                "format_version": entry.key.format_version,
+                "artifact_fingerprint": entry.key.artifact_fingerprint,
+                "parameters": entry.key.parameters,
+                "metadata": result.metadata,
+                "files": files,
+            }
+            (temporary / CACHE_MANIFEST_NAME).write_bytes(canonical_json_bytes(manifest) + b"\n")
+            (temporary / CACHE_COMPLETE_NAME).write_text("complete\n", encoding="utf-8")
+            if not self._lock_is_owned(entry, lease):
+                if self.is_valid(entry):
+                    return entry
+                msg = f"[CacheBuildLeaseLost] build lease was released for {entry.path}"
+                raise RuntimeError(msg)
+            entry.path.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                temporary.replace(entry.path)
+            except OSError:
+                if not self.is_valid(entry):
+                    raise
+            if not self.is_valid(entry):
+                msg = f"[InvalidPublishedCache] cache publication failed validation at {entry.path}"
+                raise RuntimeError(msg)
+            return entry
+        finally:
+            self._remove_path(temporary)
+
+    def _discard_invalid_entry(self, entry: CacheEntry) -> None:
+        if not entry.path.exists() or self.is_valid(entry):
+            return
+        entry.temporary_parent.mkdir(parents=True, exist_ok=True)
+        invalid_path = entry.temporary_parent / f"invalid-{uuid.uuid4().hex}"
+        try:
+            entry.path.replace(invalid_path)
+        except FileNotFoundError:
+            return
+        self._remove_path(invalid_path)
+
+    def _remove_temporary_directories(self, entry: CacheEntry) -> None:
+        if not entry.temporary_parent.is_dir():
+            return
+        for path in entry.temporary_parent.iterdir():
+            self._remove_path(path)
+
+    @staticmethod
+    def _remove_path(path: Path) -> None:
+        if path.is_dir() and not path.is_symlink():
+            shutil.rmtree(path, ignore_errors=True)
+        else:
+            path.unlink(missing_ok=True)
+
+    @staticmethod
+    def _validate_build_result(root: Path, result: CacheBuildResult) -> list[dict[str, object]]:
+        if not isinstance(result, CacheBuildResult):
+            msg = "[InvalidCacheBuildResult] cache builders must return CacheBuildResult"
+            raise TypeError(msg)
+        files: list[dict[str, object]] = []
+        for relative_path in result.files:
+            relative = Path(relative_path)
+            if relative.is_absolute() or ".." in relative.parts:
+                msg = f"[InvalidCacheFilePath] path={relative_path!r}"
+                raise ValueError(msg)
+            path = root / relative
+            if not path.is_file():
+                msg = f"[MissingCacheFile] path={path}"
+                raise RuntimeError(msg)
+            files.append({"path": relative.as_posix(), "size": path.stat().st_size})
+        canonical_json_bytes(result.metadata)
+        return files
+
+    @staticmethod
+    def _manifest_file_is_valid(root: Path, item: object) -> bool:
+        if not isinstance(item, dict):
+            return False
+        relative_path = item.get("path")
+        expected_size = item.get("size")
+        if not isinstance(relative_path, str) or not isinstance(expected_size, int):
+            return False
+        relative = Path(relative_path)
+        if relative.is_absolute() or ".." in relative.parts:
+            return False
+        path = root / relative
+        try:
+            return path.is_file() and path.stat().st_size == expected_size
+        except OSError:
+            return False

--- a/src/mvp_dataset/sources/jsonl/dataset.py
+++ b/src/mvp_dataset/sources/jsonl/dataset.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
-from pathlib import Path
 
 from mvp_dataset.core.context import RuntimeContext
 from mvp_dataset.core.dataset import Dataset
@@ -11,7 +10,7 @@ from mvp_dataset.core.types import ShardInput, TarUriRefFieldSpec
 from mvp_dataset.utils.url import normalize_paths
 
 from .iterator import _JsonlSourceIterator
-from .sharding import split_jsonl_files
+from .sharding import JSONL_SPLIT_FORMAT_VERSION, split_jsonl_files
 from .types import JsonlShuffleMode
 
 
@@ -21,6 +20,7 @@ class JsonlDataset(Dataset):
 
     _ref_fields: tuple[TarUriRefFieldSpec, ...] = ()
     _shuffle_mode: JsonlShuffleMode = "shard_aware"
+    _source_identity: str = ""
 
     @classmethod
     def from_source(
@@ -54,18 +54,19 @@ class JsonlDataset(Dataset):
             msg = f"[InvalidSourceType] expected .jsonl inputs, got={normalized_shards!r}"
             raise ValueError(msg)
 
-        source_items = split_jsonl_files(normalized_shards, runtime_context.total_slots)
+        source_plan = split_jsonl_files(normalized_shards, runtime_context.total_slots)
 
         ref_fields_tuple = tuple(ref_fields) if ref_fields else ()
 
         return cls(
             context=runtime_context,
-            _source=source_items,
+            _source=source_plan.shards,
             _resample=resample,
             _source_kind="jsonl",
             _stages=(),
             _ref_fields=ref_fields_tuple,
             _shuffle_mode=shuffle_mode,
+            _source_identity=source_plan.source.value,
         )
 
     def _build_source_stream(self, *, context: RuntimeContext) -> Iterable[object]:
@@ -76,6 +77,7 @@ class JsonlDataset(Dataset):
             resample=self._resample,
             shuffle_mode=self._shuffle_mode,
             ref_fields=self._ref_fields,
+            source_identity=self._source_identity,
             source_fingerprint=stable_fingerprint(self._source_fingerprint()),
         )
 
@@ -86,13 +88,15 @@ class JsonlDataset(Dataset):
             "resample": self._resample,
             "shuffle_mode": self._shuffle_mode,
             "ref_fields": [(field, str(base_dir)) for field, base_dir in self._ref_fields],
+            "source_fingerprint": self._source_identity,
+            "split_format_version": JSONL_SPLIT_FORMAT_VERSION,
             "shards": [
                 {
-                    "path": shard,
-                    "mtime_ns": stat.st_mtime_ns,
-                    "size": stat.st_size,
+                    "source_index": shard.source_index,
+                    "logical_path": shard.logical_path,
+                    "line_start": shard.line_start,
+                    "line_count": shard.line_count,
                 }
                 for shard in self._source
-                for stat in (Path(shard).stat(),)
             ],
         }

--- a/src/mvp_dataset/sources/jsonl/iterator.py
+++ b/src/mvp_dataset/sources/jsonl/iterator.py
@@ -15,27 +15,28 @@ from mvp_dataset.core.types import TarUriRefFieldSpec
 
 from .reader import _parse_jsonl_line
 from .refs import TarManager, resolve_ref_field_value
-from .types import JsonlShuffleMode
+from .types import JsonlShard, JsonlShuffleMode
 
 
 @dataclass(slots=True)
 class _JsonlSourceIterator:
     """Stateful iterator over JSONL shards."""
 
-    shards: Sequence[str]
+    shards: Sequence[JsonlShard]
     context: RuntimeContext
     resample: bool
     shuffle_mode: JsonlShuffleMode = "shard_aware"
     ref_fields: tuple[TarUriRefFieldSpec, ...] = ()
+    source_identity: str = ""
     source_fingerprint: str = ""
     round_index: int = 0
     shard_index: int = 0
     byte_offset: int = 0
     line_index: int = 0
     _handle: BinaryIO | None = None
-    _current_shard: str | None = None
+    _current_shard: JsonlShard | None = None
     _tar_manager: TarManager | None = None
-    _round_shards_cache: list[str] = field(default_factory=list)
+    _round_shards_cache: list[JsonlShard] = field(default_factory=list)
     _round_shards_round: int | None = None
 
     def __post_init__(self) -> None:
@@ -54,7 +55,7 @@ class _JsonlSourceIterator:
     def __next__(self) -> object:
         """Return the next output item."""
         while True:
-            shard = self._current_shard_path()
+            shard = self._current_shard_item()
             if shard is None:
                 self._close()
                 raise StopIteration
@@ -69,7 +70,14 @@ class _JsonlSourceIterator:
                 self._advance_shard()
                 continue
 
-            sample = _parse_jsonl_line(shard, self.line_index, line.decode("utf-8"), allow_preannotated=True)
+            original_line_index = shard.line_start + self.line_index
+            sample = _parse_jsonl_line(
+                shard.logical_path,
+                original_line_index,
+                line.decode("utf-8"),
+                allow_preannotated=True,
+                key=f"{self.source_identity}:{shard.source_index}:{original_line_index}",
+            )
             sample = self._resolve_refs(sample)
             self.byte_offset = self._handle.tell()
             self.line_index += 1
@@ -120,7 +128,10 @@ class _JsonlSourceIterator:
         if not isinstance(byte_offset, int) or byte_offset < 0:
             msg = "[InvalidResumeState] byte_offset must be a non-negative integer"
             raise ResumeStateError(msg)
-        if shard_index < len(round_shards) and byte_offset > Path(round_shards[shard_index]).stat().st_size:
+        if (
+            shard_index < len(round_shards)
+            and byte_offset > Path(round_shards[shard_index].physical_path).stat().st_size
+        ):
             msg = "[InvalidResumeState] byte_offset is out of range"
             raise ResumeStateError(msg)
         if shard_index == len(round_shards) and byte_offset != 0:
@@ -145,8 +156,8 @@ class _JsonlSourceIterator:
         """Return a stable fingerprint for resume compatibility checks."""
         return self.source_fingerprint
 
-    def _current_shard_path(self) -> str | None:
-        """Return the path for the currently active shard."""
+    def _current_shard_item(self) -> JsonlShard | None:
+        """Return the currently active physical shard and logical identity."""
         while True:
             round_shards = self._round_shards(self.round_index)
             if self.shard_index < len(round_shards):
@@ -159,7 +170,7 @@ class _JsonlSourceIterator:
             self.line_index = 0
             self._close_handle()
 
-    def _round_shards(self, round_index: int) -> list[str]:
+    def _round_shards(self, round_index: int) -> list[JsonlShard]:
         """Return the shard order for one resampling round."""
         if self._round_shards_round == round_index:
             return self._round_shards_cache
@@ -179,10 +190,10 @@ class _JsonlSourceIterator:
         self._round_shards_round = round_index
         return self._round_shards_cache
 
-    def _open_shard(self, shard: str) -> None:
+    def _open_shard(self, shard: JsonlShard) -> None:
         """Open the current shard for reading."""
         self._close_handle()
-        self._handle = open(shard, "rb")
+        self._handle = open(shard.physical_path, "rb")
         self._handle.seek(self.byte_offset)
         self._current_shard = shard
 

--- a/src/mvp_dataset/sources/jsonl/reader.py
+++ b/src/mvp_dataset/sources/jsonl/reader.py
@@ -54,6 +54,7 @@ def _parse_jsonl_line(
     line: str,
     *,
     allow_preannotated: bool = False,
+    key: str | None = None,
 ) -> Sample:
     """Parse one JSONL line into a sample dictionary."""
     try:
@@ -71,7 +72,7 @@ def _parse_jsonl_line(
 
     sample["__index_in_file__"] = index_in_file
     sample["__file__"] = file
-    sample["__key__"] = f"{file}:{index_in_file}"
+    sample["__key__"] = f"{file}:{index_in_file}" if key is None else key
     return sample
 
 

--- a/src/mvp_dataset/sources/jsonl/sharding.py
+++ b/src/mvp_dataset/sources/jsonl/sharding.py
@@ -1,16 +1,15 @@
-"""JSONL splitting and spill sharding."""
+"""JSONL splitting through the unified persistent cache."""
 
 from __future__ import annotations
 
-import hashlib
-import json
 import os
 import subprocess
-from collections.abc import Sequence
 from pathlib import Path
 
-from ...core.types import PathLikeStr, Sample
-from .reader import _parse_jsonl_line
+from ...cache import CacheBuildResult, CacheManager, fingerprint_local_files
+from .types import JsonlShard, JsonlSplitPlan
+
+JSONL_SPLIT_FORMAT_VERSION = 1
 
 
 def _wc_lines(path: str) -> int:
@@ -25,7 +24,7 @@ def _wc_lines(path: str) -> int:
     return int(result.stdout.strip().split()[0])
 
 
-def split_jsonl_files(paths: list[str], min_chunks: int) -> list[str]:
+def split_jsonl_files(paths: list[str], min_chunks: int) -> JsonlSplitPlan:
     """Split JSONL files into at least *min_chunks* pieces using ``split``.
 
     Args:
@@ -33,223 +32,100 @@ def split_jsonl_files(paths: list[str], min_chunks: int) -> list[str]:
         min_chunks: Minimum number of output chunks to produce.
 
     Returns:
-        Materialized shard file paths."""
-    if len(paths) >= min_chunks:
-        return paths
+        Source identity and physical shards with stable logical row ranges."""
+    manager = CacheManager()
+    source = fingerprint_local_files(paths, mode=manager.config.fingerprint_mode)
+    logical_paths = tuple(str(item["path"]) for item in source.manifest["files"])
 
-    total_lines = sum(_wc_lines(p) for p in paths)
-    if total_lines == 0 or min_chunks <= 0:
-        return paths
-
-    chunk_dir = os.path.join(os.path.dirname(paths[0]) or ".", ".chunks")
-    os.makedirs(chunk_dir, exist_ok=True)
-
-    result_paths: list[str] = []
-    for path in paths:
-        n_lines = _wc_lines(path)
-        n_splits = max(1, round(n_lines / total_lines * min_chunks))
-        if n_splits <= 1:
-            result_paths.append(path)
-            continue
-
-        stem = os.path.basename(path)
-        existing_chunks = sorted(
-            os.path.join(chunk_dir, f) for f in os.listdir(chunk_dir) if f.startswith(stem + "._chunk_")
+    if len(paths) >= min_chunks or min_chunks <= 0:
+        return JsonlSplitPlan(
+            source=source,
+            shards=tuple(
+                JsonlShard(
+                    physical_path=path,
+                    source_index=index,
+                    logical_path=logical_paths[index],
+                    line_start=0,
+                    line_count=None,
+                )
+                for index, path in enumerate(paths)
+            ),
         )
-        if existing_chunks:
-            result_paths.extend(existing_chunks)
-            continue
 
-        lines_per_chunk = max(1, (n_lines + n_splits - 1) // n_splits)
-        prefix = os.path.join(chunk_dir, stem + "._chunk_")
-        subprocess.run(
-            ["split", "-l", str(lines_per_chunk), "-d", "-a", "5", path, prefix],
-            check=True,
+    line_counts = [_wc_lines(path) for path in paths]
+    total_lines = sum(line_counts)
+    if total_lines == 0:
+        return JsonlSplitPlan(
+            source=source,
+            shards=tuple(
+                JsonlShard(
+                    physical_path=path,
+                    source_index=index,
+                    logical_path=logical_paths[index],
+                    line_start=0,
+                    line_count=line_counts[index],
+                )
+                for index, path in enumerate(paths)
+            ),
         )
-        chunk_files = sorted(
-            os.path.join(chunk_dir, f) for f in os.listdir(chunk_dir) if f.startswith(stem + "._chunk_")
-        )
-        result_paths.extend(chunk_files)
 
-    return result_paths
-
-
-def materialize_jsonl_shards(
-    files: Sequence[str],
-    *,
-    group_key: str | None,
-    num_shards: int | None,
-    target_samples_per_shard: int | None,
-    spill_buckets: int,
-    output_dir: PathLikeStr | None,
-) -> list[str]:
-    """Spill raw JSONL rows into balanced local shard files.
-
-    Args:
-        files: Input JSONL files to materialize.
-        group_key: Optional sample field used to keep related rows in the same shard.
-        num_shards: Explicit number of output shards.
-        target_samples_per_shard: Target number of samples per output shard.
-        spill_buckets: Number of temporary hash buckets used while sharding.
-        output_dir: Directory where materialized shards are written.
-
-    Returns:
-        Materialized shard file paths."""
-
-    if spill_buckets <= 0:
-        msg = f"[InvalidSpillBucketCount] spill_buckets must be > 0, got={spill_buckets}"
-        raise ValueError(msg)
-    if num_shards is not None and num_shards <= 0:
-        msg = f"[InvalidShardCount] num_shards must be > 0, got={num_shards}"
-        raise ValueError(msg)
-    if target_samples_per_shard is not None and target_samples_per_shard <= 0:
-        msg = f"[InvalidTargetSamplesPerShard] target_samples_per_shard must be > 0, got={target_samples_per_shard}"
-        raise ValueError(msg)
-
-    fingerprint = _jsonl_shard_plan_fingerprint(
-        files=files,
-        group_key=group_key,
-        num_shards=num_shards,
-        target_samples_per_shard=target_samples_per_shard,
-        spill_buckets=spill_buckets,
-    )
-    root = Path(output_dir) if output_dir is not None else Path(".mvp_dataset_jsonl_shards")
-    dataset_dir = root / fingerprint
-    manifest_path = dataset_dir / "manifest.json"
-    if manifest_path.is_file():
-        with manifest_path.open(encoding="utf-8") as handle:
-            payload = json.load(handle)
-        shard_paths = payload.get("shards")
-        if isinstance(shard_paths, list) and all(isinstance(path, str) for path in shard_paths):
-            return [str(dataset_dir / path) for path in shard_paths]
-
-    dataset_dir.mkdir(parents=True, exist_ok=True)
-    bucket_dir = dataset_dir / "buckets"
-    bucket_dir.mkdir(parents=True, exist_ok=True)
-
-    bucket_handles: dict[int, object] = {}
-    bucket_counts = [0] * spill_buckets
-    total_rows = 0
-    try:
-        for file in files:
-            with open(file, encoding="utf-8") as handle:
-                for i, line in enumerate(handle):
-                    sample = _parse_jsonl_line(file, i, line)
-                    bucket_id = _bucket_id_for_sample(sample, group_key=group_key, spill_buckets=spill_buckets)
-                    bucket_counts[bucket_id] += 1
-                    total_rows += 1
-                    bucket_handle = bucket_handles.get(bucket_id)
-                    if bucket_handle is None:
-                        bucket_path = bucket_dir / f"bucket_{bucket_id:05d}.jsonl"
-                        bucket_handle = bucket_path.open("w", encoding="utf-8")
-                        bucket_handles[bucket_id] = bucket_handle
-                    bucket_handle.write(json.dumps(sample, ensure_ascii=True) + "\n")
-    finally:
-        for handle in bucket_handles.values():
-            handle.close()
-
-    if total_rows == 0:
-        msg = "[EmptyJsonlSource] no rows found in input files"
-        raise ValueError(msg)
-
-    final_shard_count = _resolve_final_shard_count(
-        total_rows=total_rows,
-        num_shards=num_shards,
-        target_samples_per_shard=target_samples_per_shard,
-    )
-    shard_targets = _balanced_shard_targets(total_rows=total_rows, shard_count=final_shard_count)
-
-    shard_paths = [dataset_dir / f"shard_{index:05d}.jsonl" for index in range(final_shard_count)]
-    shard_handles = [path.open("w", encoding="utf-8") for path in shard_paths]
-    try:
-        current_shard = 0
-        rows_in_current_shard = 0
-        for bucket_id in sorted(i for i, c in enumerate(bucket_counts) if c > 0):
-            bucket_path = bucket_dir / f"bucket_{bucket_id:05d}.jsonl"
-            with bucket_path.open(encoding="utf-8") as handle:
-                for line in handle:
-                    if current_shard < final_shard_count - 1 and rows_in_current_shard >= shard_targets[current_shard]:
-                        current_shard += 1
-                        rows_in_current_shard = 0
-                    shard_handles[current_shard].write(line)
-                    rows_in_current_shard += 1
-        manifest = {
-            "files": list(files),
-            "group_key": group_key,
-            "num_shards": final_shard_count,
-            "target_samples_per_shard": target_samples_per_shard,
-            "spill_buckets": spill_buckets,
-            "shards": [path.name for path in shard_paths],
-        }
-        with manifest_path.open("w", encoding="utf-8") as handle:
-            json.dump(manifest, handle, ensure_ascii=True, indent=2, sort_keys=True)
-    finally:
-        for handle in shard_handles:
-            handle.close()
-
-    return [str(path) for path in shard_paths]
-
-
-def _bucket_id_for_sample(sample: Sample, *, group_key: str | None, spill_buckets: int) -> int:
-    """Return the deterministic shard bucket id for a sample key."""
-    if group_key is None:
-        key = str(sample["__key__"])
-    else:
-        value = sample.get(group_key)
-        if isinstance(value, str):
-            key = value.split("#", 1)[0]
-        elif isinstance(value, list):
-            if not value:
-                key = str(sample["__key__"])
-            elif all(isinstance(item, str) for item in value):
-                key = value[0].split("#", 1)[0]
-            else:
-                msg = f"[InvalidGroupKey] sample missing string refs for group_key={group_key!r}"
-                raise ValueError(msg)
-        else:
-            msg = f"[InvalidGroupKey] sample missing string key for group_key={group_key!r}"
-            raise ValueError(msg)
-    digest = hashlib.sha256(key.encode("utf-8")).hexdigest()
-    return int(digest[:16], 16) % spill_buckets
-
-
-def _jsonl_shard_plan_fingerprint(
-    *,
-    files: Sequence[str],
-    group_key: str | None,
-    num_shards: int | None,
-    target_samples_per_shard: int | None,
-    spill_buckets: int,
-) -> str:
-    """Return a fingerprint for the JSONL shard assignment plan."""
-    payload = {
-        "files": [(file, s.st_mtime_ns, s.st_size) for file in files for s in (Path(file).stat(),)],
-        "group_key": group_key,
-        "num_shards": num_shards,
-        "target_samples_per_shard": target_samples_per_shard,
-        "spill_buckets": spill_buckets,
+    parameters = {
+        "line_counts": line_counts,
+        "min_chunks": min_chunks,
     }
-    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
-    return hashlib.sha256(encoded).hexdigest()
 
+    def _build(temporary_dir: Path) -> CacheBuildResult:
+        files: list[str] = []
+        for index, (path, line_count) in enumerate(zip(paths, line_counts, strict=True)):
+            split_count = max(1, round(line_count / total_lines * min_chunks))
+            if split_count <= 1:
+                continue
+            lines_per_chunk = max(1, (line_count + split_count - 1) // split_count)
+            prefix_name = f"{index:05d}-{Path(path).name}.chunk-"
+            subprocess.run(
+                ["split", "-l", str(lines_per_chunk), "-d", "-a", "5", path, str(temporary_dir / prefix_name)],
+                check=True,
+            )
+            files.extend(chunk.name for chunk in sorted(temporary_dir.glob(f"{prefix_name}*")))
+        return CacheBuildResult.from_files(files)
 
-def _resolve_final_shard_count(
-    *,
-    total_rows: int,
-    num_shards: int | None,
-    target_samples_per_shard: int | None,
-) -> int:
-    """Resolve the output shard count after distributed sharding."""
-    if num_shards is not None:
-        return num_shards
-    if target_samples_per_shard is None:
-        return 1
-    return max(1, (total_rows + target_samples_per_shard - 1) // target_samples_per_shard)
+    entry = manager.ensure(
+        source=source,
+        kind="jsonl-split",
+        format_version=JSONL_SPLIT_FORMAT_VERSION,
+        parameters=parameters,
+        build=_build,
+    )
 
-
-def _balanced_shard_targets(*, total_rows: int, shard_count: int) -> list[int]:
-    """Return per-shard row targets whose totals differ by at most one."""
-
-    base = total_rows // shard_count
-    remainder = total_rows % shard_count
-    return [base + (1 if index < remainder else 0) for index in range(shard_count)]
+    result_shards: list[JsonlShard] = []
+    for index, (path, line_count) in enumerate(zip(paths, line_counts, strict=True)):
+        split_count = max(1, round(line_count / total_lines * min_chunks))
+        if split_count <= 1:
+            result_shards.append(
+                JsonlShard(
+                    physical_path=path,
+                    source_index=index,
+                    logical_path=logical_paths[index],
+                    line_start=0,
+                    line_count=line_count,
+                )
+            )
+            continue
+        lines_per_chunk = max(1, (line_count + split_count - 1) // split_count)
+        prefix_name = f"{index:05d}-{Path(path).name}.chunk-"
+        chunks = sorted(entry.path.glob(f"{prefix_name}*"))
+        if not chunks:
+            msg = f"[InvalidJsonlSplitCache] no cached chunks for input index {index}"
+            raise RuntimeError(msg)
+        for chunk_index, chunk in enumerate(chunks):
+            line_start = chunk_index * lines_per_chunk
+            result_shards.append(
+                JsonlShard(
+                    physical_path=str(chunk),
+                    source_index=index,
+                    logical_path=logical_paths[index],
+                    line_start=line_start,
+                    line_count=min(lines_per_chunk, line_count - line_start),
+                )
+            )
+    return JsonlSplitPlan(source=source, shards=tuple(result_shards))

--- a/src/mvp_dataset/sources/jsonl/types.py
+++ b/src/mvp_dataset/sources/jsonl/types.py
@@ -2,6 +2,28 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Literal
 
+from mvp_dataset.cache import SourceFingerprint
+
 JsonlShuffleMode = Literal["none", "shard_aware", "global"]
+
+
+@dataclass(frozen=True, slots=True)
+class JsonlShard:
+    """Physical JSONL shard location with a mount-independent logical identity."""
+
+    physical_path: str
+    source_index: int
+    logical_path: str
+    line_start: int
+    line_count: int | None
+
+
+@dataclass(frozen=True, slots=True)
+class JsonlSplitPlan:
+    """Prepared JSONL source identity and its physical read shards."""
+
+    source: SourceFingerprint
+    shards: tuple[JsonlShard, ...]

--- a/src/mvp_dataset/sources/lance/cache.py
+++ b/src/mvp_dataset/sources/lance/cache.py
@@ -1,0 +1,96 @@
+"""Lance source identities for persistent cache artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from collections.abc import Sequence
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+from mvp_dataset.cache import SourceFingerprint, fingerprint_source_manifest
+
+from .types import LanceDatasetSpec
+
+_LANCE_MANIFEST_VERSION_BASE = (1 << 64) - 1
+
+
+def fingerprint_lance_source(datasets: Sequence[LanceDatasetSpec]) -> SourceFingerprint:
+    """Fingerprint resolved Lance dataset versions without local mount prefixes."""
+    return fingerprint_source_manifest(lance_source_manifest(datasets))
+
+
+def lance_source_manifest(datasets: Sequence[LanceDatasetSpec]) -> dict[str, object]:
+    """Describe resolved Lance dataset versions without local mount prefixes."""
+    logical_uris = _logical_uris([dataset.uri for dataset in datasets])
+    return {
+        "schema_version": 1,
+        "kind": "lance",
+        "datasets": [
+            _dataset_manifest(dataset, logical_uri=logical_uri)
+            for dataset, logical_uri in zip(datasets, logical_uris, strict=True)
+        ],
+        "num_rows": sum(dataset.num_rows for dataset in datasets),
+    }
+
+
+def _dataset_manifest(dataset: LanceDatasetSpec, *, logical_uri: str) -> dict[str, object]:
+    manifest: dict[str, object] = {
+        "uri": logical_uri,
+        "num_rows": dataset.num_rows,
+        "row_offset": dataset.row_offset,
+        "version": dataset.version,
+    }
+    local_path = _local_path(dataset.uri)
+    if local_path is None or dataset.version is None:
+        return manifest
+
+    version_manifest = _version_manifest_path(local_path, dataset.version)
+    if version_manifest is None:
+        return manifest
+    stat = version_manifest.stat()
+    manifest["manifest"] = {
+        "name": version_manifest.name,
+        "size": stat.st_size,
+        "sha256": _hash_file(version_manifest),
+    }
+    return manifest
+
+
+def _version_manifest_path(root: Path, version: int | str) -> Path | None:
+    versions_dir = root / "_versions"
+    candidates = [versions_dir / f"{version}.manifest"]
+    try:
+        numeric_version = int(version)
+    except (TypeError, ValueError):
+        numeric_version = -1
+    if 0 <= numeric_version <= _LANCE_MANIFEST_VERSION_BASE:
+        candidates.append(versions_dir / f"{_LANCE_MANIFEST_VERSION_BASE - numeric_version}.manifest")
+    return next((path for path in candidates if path.is_file()), None)
+
+
+def _logical_uris(uris: Sequence[str]) -> tuple[str, ...]:
+    local_paths = [_local_path(uri) for uri in uris]
+    concrete_paths = [path for path in local_paths if path is not None]
+    common_root = Path(os.path.commonpath([str(path.parent) for path in concrete_paths])) if concrete_paths else None
+    return tuple(
+        uri if path is None or common_root is None else path.relative_to(common_root).as_posix()
+        for uri, path in zip(uris, local_paths, strict=True)
+    )
+
+
+def _local_path(uri: str) -> Path | None:
+    parsed = urlsplit(uri)
+    if not parsed.scheme:
+        return Path(os.path.abspath(Path(uri).expanduser()))
+    if parsed.scheme == "file" and parsed.netloc in ("", "localhost"):
+        return Path(os.path.abspath(Path(unquote(parsed.path)).expanduser()))
+    return None
+
+
+def _hash_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/src/mvp_dataset/sources/lance/dataset.py
+++ b/src/mvp_dataset/sources/lance/dataset.py
@@ -2,7 +2,7 @@
 
 import math
 from collections.abc import Iterable, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from dataclasses import replace as dataclass_replace
 
 from mvp_dataset.core.context import RuntimeContext
@@ -13,7 +13,7 @@ from mvp_dataset.core.subset import split_offsets
 from mvp_dataset.core.types import ShardInput, StageSpec
 
 from .config import resolve_lance_source_config
-from .filter import prepare_filter_index, resolve_filter_index_config
+from .filter import prepare_filter_index, validate_filter_index_config
 from .iterator import _LanceSourceIterator
 from .order import ChunkShuffleConfig, ChunkShuffleInput, resolve_chunk_shuffle_config
 from .refs import (
@@ -24,7 +24,6 @@ from .refs import (
 )
 from .source import list_lance_sources
 from .types import (
-    LanceFilterIndexConfig,
     LanceRefIndexConfigInput,
     LanceRefResolverConfig,
     LanceSelection,
@@ -42,7 +41,6 @@ class LanceDataset(Dataset):
     _chunk_shuffle: ChunkShuffleConfig | None = None
     _selection: LanceSelection | None = None
     _filter_predicate_groups: tuple[tuple[str, ...], ...] = ()
-    _filter_index_config: LanceFilterIndexConfig = field(default_factory=LanceFilterIndexConfig)
 
     @classmethod
     def from_source(
@@ -120,8 +118,6 @@ class LanceDataset(Dataset):
             prepare_filter_index(
                 source,
                 predicate_groups=self._filter_predicate_groups,
-                context=context,
-                config=self._filter_index_config,
             )
             if self._filter_predicate_groups
             else None
@@ -212,7 +208,7 @@ class LanceDataset(Dataset):
 
         Args:
             predicate: A Lance SQL WHERE expression, or a non-empty sequence of expressions combined with ``OR``.
-            index: Optional filter-index config containing ``scope``.
+            index: Reserved filter-index configuration. Non-empty mappings are rejected.
 
         Returns:
             A new filtered dataset."""
@@ -246,11 +242,10 @@ class LanceDataset(Dataset):
         if groups and len(groups[-1]) == 1 and len(group) == 1:
             group = (f"({groups[-1][0]}) AND ({group[0]})",)
             groups = groups[:-1]
-        config = self._filter_index_config if index is None else resolve_filter_index_config(index)
+        validate_filter_index_config(index)
         return dataclass_replace(
             self,
             _filter_predicate_groups=groups + (group,),
-            _filter_index_config=config,
             _resume_state=None,
         )
 
@@ -261,8 +256,6 @@ class LanceDataset(Dataset):
         return prepare_filter_index(
             self._source[0],
             predicate_groups=self._filter_predicate_groups,
-            context=self.context,
-            config=self._filter_index_config,
         ).count
 
     def split(self, fractions: Sequence[float]) -> tuple[Dataset, ...]:
@@ -340,16 +333,12 @@ class LanceDataset(Dataset):
             resolve_batch_size: Number of source samples to collect before resolving reference values.
             context: Runtime context used for sharding and deterministic randomness.
             index: Optional reference index configuration. Supported keys are:
-                ``scope``: where workers coordinate index building. Use ``"shared"`` for one
-                builder across all ranks, ``"node_local"`` for one builder per node, or
-                ``"process"`` for each process to build independently. Defaults to ``"shared"``.
                 ``build_strategy``: missing-index build strategy. Use ``"auto"``, ``"in_memory"``,
                 or ``"bucketed"``. Defaults to ``"auto"``, which uses ``"in_memory"`` for small
                 sources and ``"bucketed"`` for large sources.
                 ``bucket_count``: positive integer number of hash buckets used by ``"bucketed"``
                 builds. Defaults to ``4096``.
-                Index cache files are stored under the main Lance dataset by default. Set
-                ``MVP_DATASET_LANCE_REF_INDEX_CACHE_DIR`` to use another cache directory.
+                Index cache files use the unified ``MVP_DATASET_CACHE_DIR`` cache root.
 
         Returns:
             A dataset that resolves the requested Lance reference columns."""

--- a/src/mvp_dataset/sources/lance/filter.py
+++ b/src/mvp_dataset/sources/lance/filter.py
@@ -2,37 +2,24 @@
 
 from __future__ import annotations
 
-import hashlib
-import json
 import os
-import time
 import uuid
 from bisect import bisect_left
 from dataclasses import dataclass, field
 from itertools import groupby
 from pathlib import Path
-from urllib.parse import urlsplit
 
 import lance
 import numpy as np
 
-from mvp_dataset.core.context import RuntimeContext
+from mvp_dataset.cache import CacheBuildResult, CacheEntry, CacheManager
 
-from .types import (
-    LanceFilterIndex,
-    LanceFilterIndexConfig,
-    LanceFilterIndexConfigInput,
-    LanceSource,
-)
+from .cache import fingerprint_lance_source
+from .types import LanceFilterIndex, LanceSource
 
-FILTER_INDEX_BUILDER_VERSION = 1
-FILTER_INDEX_DIR = "_mvp_filter_index"
-FILTER_INDEX_CACHE_DIR_ENV = "MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR"
+FILTER_INDEX_FORMAT_VERSION = 1
 FILTER_INDEX_BUILD_BATCH_SIZE = 65_536
 FILTER_INDEX_MAX_PARTS = 64
-FILTER_INDEX_POLL_SECONDS = 0.25
-FILTER_INDEX_WAIT_TIMEOUT_SECONDS = 30 * 60
-FILTER_INDEX_MANIFEST = "manifest.json"
 _ROW_OFFSET_MASK = (1 << 32) - 1
 
 
@@ -46,22 +33,17 @@ class _Fragment:
     handle: object = field(repr=False, compare=False)
 
 
-def resolve_filter_index_config(index: LanceFilterIndexConfigInput) -> LanceFilterIndexConfig:
-    """Return validated Lance filter-index settings."""
+def validate_filter_index_config(index: dict[str, object] | None) -> None:
+    """Reject removed filter-index options while preserving the common filter API shape."""
     if index is None:
-        return LanceFilterIndexConfig()
+        return
     if not isinstance(index, dict):
         msg = "[InvalidLanceFilterIndexConfig] index must be a mapping"
         raise TypeError(msg)
-    unknown_keys = sorted(set(index) - {"scope"})
+    unknown_keys = sorted(index)
     if unknown_keys:
         msg = f"[InvalidLanceFilterIndexConfig] unknown config key(s): {', '.join(unknown_keys)}"
         raise ValueError(msg)
-    scope = index.get("scope", "shared")
-    if scope not in ("shared", "node_local", "process"):
-        msg = f"[InvalidLanceFilterIndexScope] expected shared, node_local, or process, got {scope!r}"
-        raise ValueError(msg)
-    return LanceFilterIndexConfig(scope=scope)
 
 
 def _plan_parts(source: LanceSource) -> tuple[tuple[_Fragment, ...], ...]:
@@ -108,30 +90,39 @@ def _plan_parts(source: LanceSource) -> tuple[tuple[_Fragment, ...], ...]:
     return tuple(tuple(fragments[start:stop]) for start, stop in zip(boundaries[:-1], boundaries[1:], strict=True))
 
 
-def _load_filter_index(index_dir: Path, identity: dict[str, object]) -> tuple[LanceFilterIndex | None, dict[str, int]]:
-    manifest_path = index_dir / FILTER_INDEX_MANIFEST
-    if not manifest_path.is_file():
-        return None, {}
-    try:
-        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-        parts = [(str(part["file"]), int(part["count"])) for part in manifest["parts"]]
-    except (KeyError, OSError, TypeError, ValueError, json.JSONDecodeError):
-        return None, {}
-    if manifest.get("identity") != identity:
-        return None, {}
+def _open_filter_index(entry: CacheEntry) -> LanceFilterIndex:
+    manifest = entry.read_manifest()
+    metadata = manifest.get("metadata")
+    if not isinstance(metadata, dict):
+        msg = f"[InvalidLanceFilterIndex] missing metadata at {entry.path}"
+        raise RuntimeError(msg)
+    raw_parts = metadata.get("parts")
+    if not isinstance(raw_parts, list):
+        msg = f"[InvalidLanceFilterIndex] invalid part metadata at {entry.path}"
+        raise RuntimeError(msg)
 
-    expected_counts = dict(parts)
     paths: list[str] = []
     offsets = [0]
-    for file_name, count in parts:
-        path = index_dir / file_name
+    for part in raw_parts:
+        if (
+            not isinstance(part, dict)
+            or not isinstance(part.get("files"), list)
+            or len(part["files"]) != 1
+            or not isinstance(part["files"][0], str)
+            or not isinstance(part.get("metadata"), dict)
+            or not isinstance(part["metadata"].get("count"), int)
+        ):
+            msg = f"[InvalidLanceFilterIndex] invalid part entry at {entry.path}"
+            raise RuntimeError(msg)
+        file_name = part["files"][0]
+        count = part["metadata"]["count"]
+        path = entry.path / file_name
         if count < 0 or not path.is_file() or path.stat().st_size != count * np.dtype(np.int64).itemsize:
-            return None, expected_counts
+            msg = f"[InvalidLanceFilterIndex] invalid part file at {path}"
+            raise RuntimeError(msg)
         paths.append(str(path))
         offsets.append(offsets[-1] + count)
-    if manifest.get("offsets") != offsets:
-        return None, expected_counts
-    return LanceFilterIndex(paths=tuple(paths), offsets=tuple(offsets), count=offsets[-1]), expected_counts
+    return LanceFilterIndex(paths=tuple(paths), offsets=tuple(offsets), count=offsets[-1])
 
 
 def _build_parts(
@@ -229,145 +220,50 @@ def _build_parts(
             tmp_path.unlink(missing_ok=True)
 
 
-def _build_part(
-    path: Path,
-    fragments: tuple[_Fragment, ...],
-    predicate_groups: tuple[tuple[str, ...], ...],
-    expected_count: int | None = None,
-) -> None:
-    _build_parts(((path, fragments, expected_count),), predicate_groups)
-
-
 def prepare_filter_index(
     source: LanceSource,
     *,
     predicate_groups: tuple[tuple[str, ...], ...],
-    context: RuntimeContext | None,
-    config: LanceFilterIndexConfig,
 ) -> LanceFilterIndex:
     """Build or open the disk-backed row mapping for Lance filter batches."""
-    predicate_hash = hashlib.sha256(
-        json.dumps(predicate_groups, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
-    ).hexdigest()
-    identity: dict[str, object] = {
-        "builder_version": FILTER_INDEX_BUILDER_VERSION,
-        "predicate_hash": predicate_hash,
-        "predicate_group_count": len(predicate_groups),
-        "predicate_count": sum(len(group) for group in predicate_groups),
-        "datasets": [
-            {
-                "uri": dataset.uri,
-                "version": dataset.version,
-                "num_rows": dataset.num_rows,
-            }
-            for dataset in source.datasets
-        ],
+    source_fingerprint = fingerprint_lance_source(source.datasets)
+    parameters = {
+        "predicate_groups": [list(group) for group in predicate_groups],
     }
-    digest = hashlib.sha256(json.dumps(identity, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()[
-        :32
-    ]
-    raw_cache_dir = os.environ.get(FILTER_INDEX_CACHE_DIR_ENV)
-    if raw_cache_dir:
-        index_root = Path(raw_cache_dir).expanduser()
-    else:
-        source_uri = source.datasets[0].uri
-        if urlsplit(source_uri).scheme:
-            msg = f"[MissingLanceFilterIndexCacheDir] set {FILTER_INDEX_CACHE_DIR_ENV} for URI source {source_uri!r}"
-            raise ValueError(msg)
-        index_root = Path(source_uri) / FILTER_INDEX_DIR
-    index_dir = index_root / f"filter-index-{digest}"
-    index_dir.mkdir(parents=True, exist_ok=True)
 
-    cached, expected_counts = _load_filter_index(index_dir, identity)
-    if cached is not None:
-        return cached
+    planned_parts: dict[str, tuple[_Fragment, ...]] = {}
 
-    parts = _plan_parts(source)
-    part_names = [f"part-{part_i:03d}.i64" for part_i in range(len(parts))]
-    if not parts:
-        for dataset in source.datasets:
-            handle = lance.dataset(dataset.uri, version=dataset.version)
-            for group in predicate_groups:
-                for predicate in group:
-                    handle.count_rows(predicate)
+    def _parts() -> tuple[str, ...]:
+        fragment_parts = _plan_parts(source)
+        if not fragment_parts:
+            fragment_parts = ((),)
+        planned_parts.update({f"part-{part_i:03d}": fragments for part_i, fragments in enumerate(fragment_parts)})
+        return tuple(planned_parts)
 
-    scope = config.scope
-    if context is None or scope == "process":
-        assignment: tuple[int, int] | None = (0, 1)
-        leader = True
-    elif scope == "shared":
-        assignment = (
-            context.rank * context.num_workers + context.worker_id,
-            context.world_size * context.num_workers,
-        )
-        leader = context.rank == 0 and context.worker_id == 0
-    else:
-        assignment = (
-            context.local_rank * context.num_workers + context.worker_id,
-            context.local_world_size * context.num_workers,
-        )
-        leader = context.local_rank == 0 and context.worker_id == 0
-
-    if leader and expected_counts:
-        _build_parts(
-            tuple(
-                (index_dir / part_name, part, expected_counts[part_name])
-                for part_name, part in zip(part_names, parts, strict=True)
-                if part_name in expected_counts
-            ),
-            predicate_groups,
-        )
-
-    if assignment is not None:
-        builder_id, builder_count = assignment
-        if len(predicate_groups) == 1 and len(predicate_groups[0]) == 1:
-            for part_i in range(builder_id, len(parts), builder_count):
-                part_name = part_names[part_i]
-                _build_part(index_dir / part_name, parts[part_i], predicate_groups, expected_counts.get(part_name))
+    def _build_part(part: str, temporary_dir: Path) -> CacheBuildResult:
+        fragments = planned_parts[part]
+        output = temporary_dir / "rows.i64"
+        if not fragments:
+            for dataset in source.datasets:
+                handle = lance.dataset(dataset.uri, version=dataset.version)
+                for group in predicate_groups:
+                    for predicate in group:
+                        handle.count_rows(predicate)
+            output.touch()
         else:
-            start = len(parts) * builder_id // builder_count
-            stop = len(parts) * (builder_id + 1) // builder_count
-            _build_parts(
-                tuple(
-                    (
-                        index_dir / part_names[part_i],
-                        parts[part_i],
-                        expected_counts.get(part_names[part_i]),
-                    )
-                    for part_i in range(start, stop)
-                ),
-                predicate_groups,
-            )
+            _build_parts(((output, fragments, None),), predicate_groups)
+        size = output.stat().st_size
+        if size % np.dtype(np.int64).itemsize != 0:
+            msg = f"[InvalidLanceFilterIndex] invalid part size for {part}"
+            raise RuntimeError(msg)
+        return CacheBuildResult.from_files([output.name], metadata={"count": size // 8})
 
-    deadline = time.monotonic() + FILTER_INDEX_WAIT_TIMEOUT_SECONDS
-    while True:
-        cached, _ = _load_filter_index(index_dir, identity)
-        if cached is not None:
-            return cached
-
-        part_paths = [index_dir / part_name for part_name in part_names]
-        if leader and all(path.is_file() and path.stat().st_size % 8 == 0 for path in part_paths):
-            counts = [path.stat().st_size // 8 for path in part_paths]
-            offsets = [0]
-            for count in counts:
-                offsets.append(offsets[-1] + count)
-            manifest = {
-                "identity": identity,
-                "parts": [
-                    {"file": part_name, "count": count} for part_name, count in zip(part_names, counts, strict=True)
-                ],
-                "offsets": offsets,
-            }
-            manifest_path = index_dir / FILTER_INDEX_MANIFEST
-            tmp_path = manifest_path.with_name(f"{manifest_path.name}.tmp-{os.getpid()}-{uuid.uuid4().hex}")
-            try:
-                tmp_path.write_text(json.dumps(manifest, sort_keys=True), encoding="utf-8")
-                os.replace(tmp_path, manifest_path)
-            finally:
-                tmp_path.unlink(missing_ok=True)
-            continue
-
-        if time.monotonic() >= deadline:
-            msg = f"[LanceFilterIndexTimeout] scope={scope!r} cache={str(index_dir)!r}"
-            raise TimeoutError(msg)
-        time.sleep(FILTER_INDEX_POLL_SECONDS)
+    entry = CacheManager().ensure(
+        source=source_fingerprint,
+        kind="lance-filter-index",
+        format_version=FILTER_INDEX_FORMAT_VERSION,
+        parameters=parameters,
+        parts=_parts,
+        build=_build_part,
+    )
+    return _open_filter_index(entry)

--- a/src/mvp_dataset/sources/lance/refs/config.py
+++ b/src/mvp_dataset/sources/lance/refs/config.py
@@ -80,7 +80,7 @@ def attach_lance_ref_columns(source: LanceSource, ref_columns: object) -> LanceS
 def resolve_ref_index_config(index: LanceRefIndexConfigInput) -> LanceRefIndexConfig:
     """Return validated reference index configuration.
 
-    ``index`` may contain ``scope``, ``build_strategy``, and ``bucket_count``.
+    ``index`` may contain ``build_strategy`` and ``bucket_count``.
     See ``LanceDataset.resolve_ref`` for accepted values and defaults.
     """
     if index is None:
@@ -88,16 +88,12 @@ def resolve_ref_index_config(index: LanceRefIndexConfigInput) -> LanceRefIndexCo
     if not isinstance(index, dict):
         msg = "[InvalidLanceRefIndexConfig] index must be a mapping"
         raise TypeError(msg)
-    allowed_keys = {"scope", "build_strategy", "bucket_count"}
+    allowed_keys = {"build_strategy", "bucket_count"}
     unknown_keys = sorted(set(index) - allowed_keys)
     if unknown_keys:
         msg = f"[InvalidLanceRefIndexConfig] unknown config key(s): {', '.join(unknown_keys)}"
         raise ValueError(msg)
 
-    scope = index.get("scope")
-    if scope is not None and scope not in ("shared", "node_local", "process"):
-        msg = f"[InvalidLanceRefIndexScope] expected shared, node_local, or process, got {scope!r}"
-        raise ValueError(msg)
     build_strategy = index.get("build_strategy")
     if build_strategy is not None and build_strategy not in ("auto", "in_memory", "bucketed"):
         msg = f"[InvalidLanceRefIndexBuildStrategy] expected auto, in_memory, or bucketed, got {build_strategy!r}"
@@ -110,7 +106,6 @@ def resolve_ref_index_config(index: LanceRefIndexConfigInput) -> LanceRefIndexCo
             raise ValueError(msg)
 
     return LanceRefIndexConfig(
-        scope=scope,
         build_strategy=build_strategy,
         bucket_count=bucket_count,
     )

--- a/src/mvp_dataset/sources/lance/refs/index.py
+++ b/src/mvp_dataset/sources/lance/refs/index.py
@@ -4,10 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 import shutil
-import time
-import uuid
 from collections.abc import Iterable, Sequence
 from pathlib import Path
 from typing import Any
@@ -16,18 +13,14 @@ import lance
 import numpy as np
 import pyarrow as pa
 
-from mvp_dataset.core.context import RuntimeContext
+from mvp_dataset.cache import CacheBuildResult, CacheManager
 
-from ..types import LanceRefIndexConfig, LanceRefIndexScope, LanceRefSpec, LanceSource
+from ..cache import fingerprint_lance_source, lance_source_manifest
+from ..types import LanceRefIndexConfig, LanceRefSpec, LanceSource
 
-REF_INDEX_BUILDER_VERSION = 1
+REF_INDEX_FORMAT_VERSION = 1
 REF_INDEX_MISSING_ROW = -1
-REF_INDEX_MANIFEST = "metadata.json"
-REF_INDEX_DIR = "_mvp_ref_index"
-REF_INDEX_CACHE_DIR_ENV = "MVP_DATASET_LANCE_REF_INDEX_CACHE_DIR"
 REF_INDEX_BUILD_BATCH_SIZE = 65536
-REF_INDEX_LOCK_POLL_SECONDS = 0.25
-REF_INDEX_WAIT_TIMEOUT_SECONDS = 30 * 60
 REF_INDEX_DEFAULT_BUILD_STRATEGY = "auto"
 REF_INDEX_DEFAULT_BUCKET_COUNT = 4096
 REF_INDEX_AUTO_BUCKETED_MIN_ROWS = 1_000_000
@@ -114,27 +107,9 @@ class _BucketWriter:
         self.close()
 
 
-def _resolve_ref_index_root(source: LanceSource) -> Path:
-    raw_cache_dir = os.environ.get(REF_INDEX_CACHE_DIR_ENV)
-    if raw_cache_dir:
-        return Path(raw_cache_dir).expanduser()
-    return Path(source.datasets[0].uri) / REF_INDEX_DIR
-
-
 def _ref_manifest_fingerprint(ref: LanceRefSpec) -> dict[str, Any]:
     """Return a fingerprint for reference source manifests."""
-    datasets = [
-        {
-            "uri": dataset.uri,
-            "num_rows": dataset.num_rows,
-            "version": dataset.version,
-        }
-        for dataset in ref.datasets
-    ]
-    return {
-        "datasets": datasets,
-        "num_rows": sum(dataset.num_rows for dataset in ref.datasets),
-    }
+    return lance_source_manifest(ref.datasets)
 
 
 def _open_ref_value_source(ref: LanceRefSpec) -> LanceSource:
@@ -142,79 +117,13 @@ def _open_ref_value_source(ref: LanceRefSpec) -> LanceSource:
     return LanceSource(datasets=ref.datasets)
 
 
-def _ref_index_is_valid(
-    index_dir: Path,
-    manifest: dict[str, Any],
-    ref_files: dict[str, dict[str, Any]],
-    active_refs: Sequence[LanceRefSpec],
-) -> bool:
-    """Return whether an existing reference index matches the manifest."""
-    manifest_path = index_dir / REF_INDEX_MANIFEST
-    if not index_dir.exists() or not manifest_path.exists():
-        return False
-    try:
-        stored_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return False
-    return stored_manifest == manifest and all(
-        (index_dir / ref_files[ref.column]["offsets_file"]).exists()
-        and (index_dir / ref_files[ref.column]["entries_file"]).exists()
-        for ref in active_refs
-    )
-
-
-def _is_ref_index_builder(context: RuntimeContext | None, scope: LanceRefIndexScope) -> bool:
-    """Return whether this worker should build the reference index."""
-    if context is None or scope == "process":
-        return True
-    if scope == "shared":
-        return context.rank == 0 and context.worker_id == 0
-    if scope == "node_local":
-        return context.local_rank == 0 and context.worker_id == 0
-    return False
-
-
-def _wait_for_ref_index(
-    index_dir: Path,
-    manifest: dict[str, Any],
-    ref_files: dict[str, dict[str, Any]],
-    active_refs: Sequence[LanceRefSpec],
-    *,
-    timeout_seconds: float = REF_INDEX_WAIT_TIMEOUT_SECONDS,
-) -> None:
-    """Wait for a reference index built by another worker."""
-    deadline = time.monotonic() + timeout_seconds
-    poll_seconds = REF_INDEX_LOCK_POLL_SECONDS
-    while not _ref_index_is_valid(index_dir, manifest, ref_files, active_refs):
-        if time.monotonic() >= deadline:
-            msg = f"[LanceRefIndexTimeout] timed out waiting for ref index at {index_dir}"
-            raise TimeoutError(msg)
-        time.sleep(poll_seconds)
-        poll_seconds = min(poll_seconds * 2, 5.0)
-
-
-def _publish_ref_index(tmp_index_dir: Path, index_dir: Path) -> None:
-    """Publish reference index files atomically."""
-    try:
-        tmp_index_dir.replace(index_dir)
-    except FileExistsError:
-        return
-    except OSError:
-        if not index_dir.exists():
-            raise
-
-
 def _build_ref_index_in_memory(
     index_dir: Path,
-    manifest: dict[str, Any],
     ref_files: dict[str, dict[str, Any]],
     active_refs: Sequence[LanceRefSpec],
     source: LanceSource,
 ) -> None:
     """Build lookup indexes with an in-memory key-to-entry map."""
-    manifest_path = index_dir / REF_INDEX_MANIFEST
-    index_dir.mkdir(parents=True, exist_ok=False)
-
     offsets_by_column: dict[str, np.memmap] = {}
     requested_positions: dict[str, dict[Any, list[int]]] = {ref.column: {} for ref in active_refs}
     entry_counts = {ref.column: 0 for ref in active_refs}
@@ -283,14 +192,9 @@ def _build_ref_index_in_memory(
         if callable(flush):
             flush()
 
-    tmp_manifest_path = manifest_path.with_suffix(f"{manifest_path.suffix}.tmp")
-    tmp_manifest_path.write_text(json.dumps(manifest, sort_keys=True, indent=2, default=str), encoding="utf-8")
-    tmp_manifest_path.replace(manifest_path)
-
 
 def _build_ref_index_bucketed(
     index_dir: Path,
-    manifest: dict[str, Any],
     ref_files: dict[str, dict[str, Any]],
     active_refs: Sequence[LanceRefSpec],
     source: LanceSource,
@@ -298,9 +202,7 @@ def _build_ref_index_bucketed(
     bucket_count: int,
 ) -> None:
     """Build lookup indexes with hash buckets on disk."""
-    manifest_path = index_dir / REF_INDEX_MANIFEST
     bucket_root = index_dir / "_bucket_tmp"
-    index_dir.mkdir(parents=True, exist_ok=False)
 
     offsets_by_column: dict[str, np.memmap] = {}
     entry_counts = {ref.column: 0 for ref in active_refs}
@@ -374,10 +276,6 @@ def _build_ref_index_bucketed(
     finally:
         shutil.rmtree(bucket_root, ignore_errors=True)
 
-    tmp_manifest_path = manifest_path.with_suffix(f"{manifest_path.suffix}.tmp")
-    tmp_manifest_path.write_text(json.dumps(manifest, sort_keys=True, indent=2, default=str), encoding="utf-8")
-    tmp_manifest_path.replace(manifest_path)
-
 
 def _write_ref_buckets(ref: LanceRefSpec, bucket_dir: Path, *, bucket_count: int) -> None:
     """Write reference keys to hash buckets."""
@@ -434,7 +332,6 @@ def prepare_ref_indexes(
     source: LanceSource,
     *,
     ref_names: Sequence[str],
-    context: RuntimeContext | None = None,
     config: LanceRefIndexConfig,
 ) -> LanceSource:
     """Ensure all configured Lance reference indexes are available.
@@ -442,7 +339,6 @@ def prepare_ref_indexes(
     Args:
         source: Lance source specification.
         ref_names: Reference column names to prepare.
-        context: Runtime context used for sharding and deterministic randomness.
         config: Reference index configuration.
 
     Returns:
@@ -466,16 +362,8 @@ def prepare_ref_indexes(
         }
         for ref_i, ref in enumerate(active_refs)
     }
-    manifest = {
-        "builder_version": REF_INDEX_BUILDER_VERSION,
-        "main_datasets": [
-            {
-                "uri": dataset.uri,
-                "num_rows": dataset.num_rows,
-                "version": dataset.version,
-            }
-            for dataset in source.datasets
-        ],
+    source_fingerprint = fingerprint_lance_source(source.datasets)
+    parameters = {
         "main_total_rows": source.total_rows,
         "refs": {
             ref.column: {
@@ -487,40 +375,40 @@ def prepare_ref_indexes(
             for ref in active_refs
         },
     }
-    digest = hashlib.sha256(json.dumps(manifest, sort_keys=True, default=str).encode("utf-8")).hexdigest()[:32]
-    index_root = _resolve_ref_index_root(source)
-    index_dir = index_root / f"ref-index-{digest}"
-    scope = config.scope or "shared"
     build_strategy = config.build_strategy or REF_INDEX_DEFAULT_BUILD_STRATEGY
     if build_strategy == "auto":
         build_strategy = "bucketed" if source.total_rows >= REF_INDEX_AUTO_BUCKETED_MIN_ROWS else "in_memory"
     bucket_count = config.bucket_count or REF_INDEX_DEFAULT_BUCKET_COUNT
 
-    if not _ref_index_is_valid(index_dir, manifest, ref_files, active_refs):
-        if _is_ref_index_builder(context, scope):
-            tmp_index_dir = index_root / ".tmp" / f"ref-index-{digest}-{os.getpid()}-{uuid.uuid4().hex}"
-            try:
-                if build_strategy == "in_memory":
-                    _build_ref_index_in_memory(tmp_index_dir, manifest, ref_files, active_refs, source)
-                else:
-                    _build_ref_index_bucketed(
-                        tmp_index_dir,
-                        manifest,
-                        ref_files,
-                        active_refs,
-                        source,
-                        bucket_count=bucket_count,
-                    )
-                if not _ref_index_is_valid(index_dir, manifest, ref_files, active_refs):
-                    _publish_ref_index(tmp_index_dir, index_dir)
-            finally:
-                shutil.rmtree(tmp_index_dir, ignore_errors=True)
+    def _build(temporary_dir: Path) -> CacheBuildResult:
+        if build_strategy == "in_memory":
+            _build_ref_index_in_memory(temporary_dir, ref_files, active_refs, source)
         else:
-            _wait_for_ref_index(index_dir, manifest, ref_files, active_refs)
+            _build_ref_index_bucketed(
+                temporary_dir,
+                ref_files,
+                active_refs,
+                source,
+                bucket_count=bucket_count,
+            )
+        files = [
+            file_name
+            for ref in active_refs
+            for file_name in (
+                ref_files[ref.column]["offsets_file"],
+                ref_files[ref.column]["entries_file"],
+            )
+        ]
+        return CacheBuildResult.from_files(files)
 
-    if not _ref_index_is_valid(index_dir, manifest, ref_files, active_refs):
-        msg = f"[InvalidLanceRefIndex] ref index was not completed at {index_dir}"
-        raise RuntimeError(msg)
+    entry = CacheManager().ensure(
+        source=source_fingerprint,
+        kind="lance-ref-index",
+        format_version=REF_INDEX_FORMAT_VERSION,
+        parameters=parameters,
+        build=_build,
+    )
+    index_dir = entry.path
 
     prepared_refs: list[LanceRefSpec] = []
     for ref in active_refs:

--- a/src/mvp_dataset/sources/lance/refs/resolve.py
+++ b/src/mvp_dataset/sources/lance/refs/resolve.py
@@ -139,13 +139,12 @@ class LanceResolveRefFactory:
     ref_names: tuple[str, ...]
     config: LanceRefResolverConfig
 
-    def __call__(self, context: RuntimeContext) -> LanceRefResolverAssembler:
+    def __call__(self, _context: RuntimeContext) -> LanceRefResolverAssembler:
         """Apply this callable object."""
         return LanceRefResolverAssembler(
             source=self.source,
             ref_names=self.ref_names,
             config=self.config,
-            context=context,
         )
 
 
@@ -158,7 +157,6 @@ class LanceRefResolverAssembler:
         source: LanceSource,
         ref_names: Sequence[str],
         config: LanceRefResolverConfig,
-        context: RuntimeContext | None = None,
     ) -> None:
         """Initialize the object."""
         if config.resolve_batch_size <= 0:
@@ -169,7 +167,6 @@ class LanceRefResolverAssembler:
         self.source = prepare_ref_indexes(
             source,
             ref_names=self.ref_names,
-            context=context,
             config=config.index,
         )
         self.config = config
@@ -204,7 +201,6 @@ class LanceRefResolverAssembler:
                 "ref_names": list(self.ref_names),
                 "resolve_batch_size": self.config.resolve_batch_size,
                 "ref_index": {
-                    "scope": self.config.index.scope,
                     "build_strategy": self.config.index.build_strategy,
                     "bucket_count": self.config.index.bucket_count,
                 },

--- a/src/mvp_dataset/sources/lance/types.py
+++ b/src/mvp_dataset/sources/lance/types.py
@@ -6,9 +6,6 @@ from dataclasses import dataclass, field
 from typing import Literal
 
 LanceShuffleMode = Literal["none", "global", "chunk"]
-LanceFilterIndexScope = Literal["shared", "node_local", "process"]
-LanceFilterIndexConfigInput = dict[str, object] | None
-LanceRefIndexScope = Literal["shared", "node_local", "process"]
 LanceRefIndexBuildStrategy = Literal["auto", "in_memory", "bucketed"]
 LanceRefIndexConfigInput = dict[str, object] | None
 
@@ -22,13 +19,6 @@ class LanceDatasetSpec:
     row_offset: int
     version: int | str | None = None
     handle: object | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class LanceFilterIndexConfig:
-    """Filter-index build configuration."""
-
-    scope: LanceFilterIndexScope = "shared"
 
 
 @dataclass(frozen=True, slots=True)
@@ -59,7 +49,6 @@ class LanceRefSpec:
 class LanceRefIndexConfig:
     """Reference index preparation configuration."""
 
-    scope: LanceRefIndexScope | None = None
     build_strategy: LanceRefIndexBuildStrategy | None = None
     bucket_count: int | None = None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Shared test configuration."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cache_dir(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("MVP_DATASET_CACHE_DIR", str(tmp_path / "mvp-cache"))

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,414 @@
+from __future__ import annotations
+
+import multiprocessing
+import os
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from mvp_dataset import CacheConfig, clear_cache, list_cache_entries
+from mvp_dataset.cache import (
+    CacheBuildResult,
+    CacheKey,
+    CacheManager,
+    SourceFingerprint,
+    fingerprint_local_files,
+)
+from mvp_dataset.cache.fingerprint import fingerprint_source_manifest
+from mvp_dataset.sources.jsonl.sharding import split_jsonl_files
+from mvp_dataset.sources.lance.cache import fingerprint_lance_source
+from mvp_dataset.sources.lance.types import LanceDatasetSpec
+
+
+def _cache_config(root: Path) -> CacheConfig:
+    return CacheConfig(
+        root=root,
+        wait_timeout_seconds=2,
+        poll_interval_seconds=0.01,
+    )
+
+
+def _source():
+    return fingerprint_source_manifest(
+        {
+            "schema_version": 1,
+            "kind": "test",
+            "files": [{"path": "source.bin", "size": 1, "mtime_ns": 1}],
+        }
+    )
+
+
+def _write_payload(root: Path, payload: bytes = b"value") -> CacheBuildResult:
+    (root / "payload.bin").write_bytes(payload)
+    return CacheBuildResult.from_files(["payload.bin"])
+
+
+def _hold_cache_lock_until_killed(cache_root: str, ready) -> None:
+    manager = CacheManager(_cache_config(Path(cache_root)))
+    source = _source()
+    key = CacheKey.create(
+        source_fingerprint=source.value,
+        kind="test-artifact",
+        format_version=1,
+        parameters={},
+    )
+    entry = manager.entry(key)
+    lease = manager._acquire_lock(entry)
+    if lease is None:
+        ready.put(False)
+        return
+    partial = entry.temporary_parent / "crashed-build"
+    partial.mkdir(parents=True)
+    (partial / "partial.bin").write_bytes(b"partial")
+    ready.put(True)
+    time.sleep(60)
+
+
+def test_source_fingerprint_ignores_mount_prefix(tmp_path) -> None:
+    source_root = tmp_path / "source"
+    source_root.mkdir()
+    source_file = source_root / "shard.jsonl"
+    source_file.write_text("{}\n", encoding="utf-8")
+    mount_a = tmp_path / "mount-a"
+    mount_b = tmp_path / "mount-b"
+    mount_a.symlink_to(source_root, target_is_directory=True)
+    mount_b.symlink_to(source_root, target_is_directory=True)
+
+    first = fingerprint_local_files([mount_a / source_file.name])
+    second = fingerprint_local_files([mount_b / source_file.name])
+
+    assert first.value == second.value
+    assert first.manifest["files"] == second.manifest["files"]
+    assert str(tmp_path) not in str(first.manifest)
+
+
+def test_content_fingerprint_ignores_mtime_changes(tmp_path) -> None:
+    source = tmp_path / "source.jsonl"
+    source.write_text("{}\n", encoding="utf-8")
+    first = fingerprint_local_files([source], mode="content")
+    changed_time = source.stat().st_mtime + 10
+    os.utime(source, (changed_time, changed_time))
+
+    second = fingerprint_local_files([source], mode="content")
+
+    assert first == second
+
+
+def test_source_fingerprint_manifest_is_immutable(tmp_path) -> None:
+    source = tmp_path / "source.jsonl"
+    source.write_text("{}\n", encoding="utf-8")
+    fingerprint = fingerprint_local_files([source], mode="content")
+
+    manifest = fingerprint.manifest
+    manifest["files"][0]["size"] = 999
+
+    assert fingerprint.manifest["files"][0]["size"] == 3
+    with pytest.raises(ValueError, match=r"\[InvalidSourceFingerprint\]"):
+        SourceFingerprint(value="0" * 64, manifest=fingerprint.manifest)
+
+
+def test_lance_source_fingerprint_ignores_mount_prefix(tmp_path) -> None:
+    source_root = tmp_path / "source"
+    version_dir = source_root / "dataset.lance" / "_versions"
+    version_dir.mkdir(parents=True)
+    (version_dir / f"{(1 << 64) - 1 - 7}.manifest").write_bytes(b"lance-manifest")
+    mount_a = tmp_path / "mount-a"
+    mount_b = tmp_path / "mount-b"
+    mount_a.symlink_to(source_root, target_is_directory=True)
+    mount_b.symlink_to(source_root, target_is_directory=True)
+
+    first = fingerprint_lance_source(
+        (LanceDatasetSpec(str(mount_a / "dataset.lance"), num_rows=5, row_offset=0, version=7),)
+    )
+    second = fingerprint_lance_source(
+        (LanceDatasetSpec(f"file://{mount_b / 'dataset.lance'}", num_rows=5, row_offset=0, version=7),)
+    )
+
+    assert first == second
+    assert str(tmp_path) not in str(first.manifest)
+    assert first.manifest["datasets"][0]["manifest"]["name"].endswith(".manifest")
+
+
+def test_cache_manager_reuses_completed_entry(tmp_path) -> None:
+    manager = CacheManager(_cache_config(tmp_path / "cache"))
+    calls = 0
+
+    def build(root: Path) -> CacheBuildResult:
+        nonlocal calls
+        calls += 1
+        return _write_payload(root)
+
+    parameters = {"columns": ("id", "value")}
+    first = manager.ensure(source=_source(), kind="test-artifact", format_version=1, parameters=parameters, build=build)
+    second = manager.ensure(
+        source=_source(), kind="test-artifact", format_version=1, parameters=parameters, build=build
+    )
+
+    assert first.path == second.path
+    assert calls == 1
+    assert first.path.parts[-3] == _source().value
+    assert first.path.parts[-2] == "test-artifact-v1"
+    assert first.key.parameters == {"columns": ["id", "value"]}
+    assert first.complete_path.is_file()
+    assert manager.is_valid(first)
+
+
+@pytest.mark.parametrize("format_version", [True, 1.5, "1"])
+def test_cache_key_requires_integer_format_version(format_version) -> None:
+    with pytest.raises(ValueError, match=r"\[InvalidCacheFormatVersion\]"):
+        CacheKey.create(
+            source_fingerprint=_source().value,
+            kind="test-artifact",
+            format_version=format_version,
+            parameters={},
+        )
+
+
+def test_cache_manager_does_not_publish_failed_build(tmp_path) -> None:
+    manager = CacheManager(_cache_config(tmp_path / "cache"))
+
+    def fail(root: Path) -> CacheBuildResult:
+        (root / "partial.bin").write_bytes(b"partial")
+        raise RuntimeError("build failed")
+
+    with pytest.raises(RuntimeError, match="build failed"):
+        manager.ensure(source=_source(), kind="test-artifact", format_version=1, parameters={}, build=fail)
+
+    assert manager.list_entries() == ()
+    entry = manager.ensure(
+        source=_source(),
+        kind="test-artifact",
+        format_version=1,
+        parameters={},
+        build=_write_payload,
+    )
+    assert manager.is_valid(entry)
+    assert not (entry.path / "partial.bin").exists()
+
+
+def test_cache_manager_recovers_lock_and_partial_directory_after_sigkill(tmp_path) -> None:
+    manager = CacheManager(_cache_config(tmp_path / "cache"))
+    source = _source()
+    key = CacheKey.create(
+        source_fingerprint=source.value,
+        kind="test-artifact",
+        format_version=1,
+        parameters={},
+    )
+    entry = manager.entry(key)
+    context = multiprocessing.get_context("spawn")
+    ready = context.Queue()
+    process = context.Process(target=_hold_cache_lock_until_killed, args=(str(manager.root), ready))
+    process.start()
+    assert ready.get(timeout=10) is True
+    process.kill()
+    process.join(timeout=10)
+    assert process.exitcode is not None and process.exitcode < 0
+
+    recovered = manager.ensure(
+        source=source,
+        kind="test-artifact",
+        format_version=1,
+        parameters={},
+        build=_write_payload,
+    )
+
+    assert manager.is_valid(recovered)
+    assert not (entry.temporary_parent / "crashed-build").exists()
+    assert entry.lock_path.is_file()
+
+
+def test_released_lease_cannot_unlock_current_lease(tmp_path) -> None:
+    manager = CacheManager(_cache_config(tmp_path / "cache"))
+    key = CacheKey.create(
+        source_fingerprint=_source().value,
+        kind="test-artifact",
+        format_version=1,
+        parameters={},
+    )
+    entry = manager.entry(key)
+    previous_lease = manager._acquire_lock(entry)
+    assert previous_lease is not None
+    assert manager._acquire_lock(entry) is None
+    manager._release_lock(previous_lease)
+
+    current_lease = manager._acquire_lock(entry)
+    assert current_lease is not None
+    manager._release_lock(previous_lease)
+
+    assert manager._lock_is_owned(entry, current_lease)
+    manager._release_lock(current_lease)
+    assert entry.lock_path.is_file()
+
+
+def test_cache_manager_serializes_concurrent_builds(tmp_path) -> None:
+    manager = CacheManager(_cache_config(tmp_path / "cache"))
+    calls = 0
+    calls_lock = threading.Lock()
+
+    def build(root: Path) -> CacheBuildResult:
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+        time.sleep(0.1)
+        return _write_payload(root)
+
+    def ensure():
+        return manager.ensure(
+            source=_source(),
+            kind="test-artifact",
+            format_version=1,
+            parameters={},
+            build=build,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        entries = list(executor.map(lambda _: ensure(), range(2)))
+
+    assert entries[0].path == entries[1].path
+    assert calls == 1
+
+
+def test_cache_manager_builds_parts_concurrently(tmp_path) -> None:
+    manager = CacheManager(_cache_config(tmp_path / "cache"))
+    part_names = tuple(f"part-{index}" for index in range(6))
+    built_by: dict[str, int] = {}
+    built_lock = threading.Lock()
+
+    def ensure(worker: int):
+        def build_part(part: str, root: Path) -> CacheBuildResult:
+            with built_lock:
+                assert part not in built_by
+                built_by[part] = worker
+            time.sleep(0.03)
+            (root / "payload.bin").write_text(part, encoding="utf-8")
+            return CacheBuildResult.from_files(["payload.bin"], metadata={"worker": worker})
+
+        return manager.ensure(
+            source=_source(),
+            kind="partitioned-artifact",
+            format_version=1,
+            parameters={},
+            parts=lambda: part_names,
+            build=build_part,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        entries = list(executor.map(ensure, range(2)))
+
+    assert entries[0].path == entries[1].path
+    assert set(built_by) == set(part_names)
+    assert set(built_by.values()) == {0, 1}
+    assert all((entries[0].path / part / "payload.bin").is_file() for part in part_names)
+    assert manager.is_valid(entries[0])
+    assert not entries[0].temporary_parent.exists() or not any(entries[0].temporary_parent.iterdir())
+
+
+def test_cache_manager_resumes_failed_partitioned_build(tmp_path) -> None:
+    manager = CacheManager(_cache_config(tmp_path / "cache"))
+    calls = {part: 0 for part in ("part-0", "part-1", "part-2")}
+
+    def build_part(part: str, root: Path) -> CacheBuildResult:
+        calls[part] += 1
+        (root / "payload.bin").write_text(part, encoding="utf-8")
+        if part == "part-1" and calls[part] == 1:
+            raise RuntimeError("part build failed")
+        return CacheBuildResult.from_files(["payload.bin"])
+
+    with pytest.raises(RuntimeError, match="part build failed"):
+        manager.ensure(
+            source=_source(),
+            kind="partitioned-artifact",
+            format_version=1,
+            parameters={},
+            parts=lambda: tuple(calls),
+            build=build_part,
+        )
+
+    assert manager.list_entries() == ()
+    entry = manager.ensure(
+        source=_source(),
+        kind="partitioned-artifact",
+        format_version=1,
+        parameters={},
+        parts=lambda: tuple(calls),
+        build=build_part,
+    )
+
+    assert calls == {"part-0": 1, "part-1": 2, "part-2": 1}
+    assert manager.is_valid(entry)
+
+
+def test_cache_manager_recovers_abandoned_partition_temporary_directory(tmp_path) -> None:
+    manager = CacheManager(_cache_config(tmp_path / "cache"))
+    source = _source()
+    key = CacheKey.create(
+        source_fingerprint=source.value,
+        kind="partitioned-artifact",
+        format_version=1,
+        parameters={},
+    )
+    entry = manager.entry(key)
+    manager._ensure_source_manifest(source)
+    attempt = manager._ensure_partition_attempt(entry, ("part-0",), time.monotonic() + 1)
+    assert attempt is not None
+    lock_path = attempt.locks_path / "part-0.lock"
+    lease = manager._acquire_path_lock(lock_path)
+    assert lease is not None
+    partial = attempt.temporary_path / "part-0" / "crashed"
+    partial.mkdir(parents=True)
+    (partial / "payload.bin").write_bytes(b"partial")
+    manager._release_path_lock(lease)
+
+    recovered = manager.ensure(
+        source=source,
+        kind="partitioned-artifact",
+        format_version=1,
+        parameters={},
+        parts=lambda: ("part-0",),
+        build=lambda _part, root: _write_payload(root),
+    )
+
+    assert manager.is_valid(recovered)
+    assert not partial.exists()
+
+
+@pytest.mark.parametrize("part", ["manifest.json", "complete"])
+def test_cache_manager_rejects_reserved_partition_names(tmp_path, part: str) -> None:
+    manager = CacheManager(_cache_config(tmp_path / "cache"))
+
+    with pytest.raises(ValueError, match=r"\[InvalidCachePartName\]"):
+        manager.ensure(
+            source=_source(),
+            kind="partitioned-artifact",
+            format_version=1,
+            parameters={},
+            parts=lambda: (part,),
+            build=lambda _part, root: _write_payload(root),
+        )
+
+
+def test_jsonl_splits_use_unified_cache(tmp_path, monkeypatch) -> None:
+    source = tmp_path / "records.jsonl"
+    source.write_text("".join(f'{{"id": {index}}}\n' for index in range(8)), encoding="utf-8")
+    cache_root = tmp_path / "shared-cache"
+    monkeypatch.setenv("MVP_DATASET_CACHE_DIR", str(cache_root))
+
+    first = split_jsonl_files([str(source)], min_chunks=2)
+    second = split_jsonl_files([str(source)], min_chunks=2)
+
+    assert first == second
+    assert len(first.shards) == 2
+    assert all(Path(shard.physical_path).is_relative_to(cache_root) for shard in first.shards)
+    assert [shard.logical_path for shard in first.shards] == ["records.jsonl", "records.jsonl"]
+    assert [shard.line_start for shard in first.shards] == [0, 4]
+    assert [shard.line_count for shard in first.shards] == [4, 4]
+    assert not (tmp_path / ".chunks").exists()
+    entries = list_cache_entries(cache_root)
+    assert len(entries) == 1
+    assert entries[0].kind == "jsonl-split"
+    assert clear_cache(cache_root, kind="jsonl-split") == 1
+    assert list_cache_entries(cache_root) == ()

--- a/tests/test_lance_filter.py
+++ b/tests/test_lance_filter.py
@@ -32,6 +32,7 @@ def _distributed_filter_worker(
     world_size: int,
     worker_id: int,
     num_workers: int,
+    start_barrier,
     results,
 ) -> None:
     try:
@@ -42,16 +43,15 @@ def _distributed_filter_worker(
             LOCAL_WORLD_SIZE=str(world_size),
             WORKER=str(worker_id),
             NUM_WORKERS=str(num_workers),
-            MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR=cache_dir,
+            MVP_DATASET_CACHE_DIR=cache_dir,
         )
         from mvp_dataset.sources.lance import filter as lance_filter
 
-        lance_filter.FILTER_INDEX_WAIT_TIMEOUT_SECONDS = 20
         built_parts = []
         build_parts = lance_filter._build_parts
 
         def tracked_build_parts(entries, predicate_groups):
-            built_parts.extend(path.name for path, _, _ in entries)
+            built_parts.extend(path.parent.parent.name for path, _, _ in entries)
             return build_parts(entries, predicate_groups)
 
         lance_filter._build_parts = tracked_build_parts
@@ -67,13 +67,14 @@ def _distributed_filter_worker(
                 num_workers=num_workers,
             ),
         ).filter(filter_arg)
+        start_barrier.wait(timeout=20)
         results.put(("ok", {"values": _values(dataset), "built_parts": built_parts}))
     except Exception:
         results.put(("error", traceback.format_exc()))
 
 
 def test_lance_filter_uses_source_order_and_projection(tmp_path, monkeypatch) -> None:
-    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setenv("MVP_DATASET_CACHE_DIR", str(tmp_path / "cache"))
     source = write_lance_dataset(tmp_path, build_records(20), max_rows_per_file=3)
 
     rows = list(Dataset.from_source("lance", source, columns=["id"]).filter("value >= 4").filter("value < 9"))
@@ -86,7 +87,7 @@ def test_lance_filter_uses_source_order_and_projection(tmp_path, monkeypatch) ->
 def test_lance_filter_batches_are_or_combined_deduplicated_and_source_ordered(tmp_path, monkeypatch) -> None:
     import lance
 
-    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setenv("MVP_DATASET_CACHE_DIR", str(tmp_path / "cache"))
     source = write_lance_dataset(tmp_path, build_records(20), max_rows_per_file=3)
     lance.dataset(source).create_scalar_index("value", "BTREE")
     filters = []
@@ -108,13 +109,13 @@ def test_lance_filter_batches_are_or_combined_deduplicated_and_source_ordered(tm
     )
 
     assert _values(dataset) == [1, 2, 4, 7, 18]
-    assert len(filters) == 3
+    assert len(filters) % 3 == 0
     assert {item for item, _ in filters} == {"value IN (7, 1, 4)", "value IN (4, 2, 7)", "value = 18"}
     assert all(use_scalar_index is True for _, use_scalar_index in filters)
 
 
 def test_lance_filter_batches_preserve_and_across_calls(tmp_path, monkeypatch) -> None:
-    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setenv("MVP_DATASET_CACHE_DIR", str(tmp_path / "cache"))
     source = write_lance_dataset(tmp_path, build_records(20), max_rows_per_file=3)
 
     dataset = Dataset.from_source("lance", source).filter(["value < 5", "value > 15"]).filter("value % 2 = 0")
@@ -131,7 +132,7 @@ def test_lance_filter_batches_preserve_and_across_calls(tmp_path, monkeypatch) -
 
 
 def test_lance_filter_batches_cross_bitmap_chunk_boundary(tmp_path, monkeypatch) -> None:
-    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setenv("MVP_DATASET_CACHE_DIR", str(tmp_path / "cache"))
     source = write_lance_dataset(tmp_path, build_records(65_540))
 
     dataset = Dataset.from_source("lance", source).filter(["value IN (0, 65535)", "value IN (65536, 65539)"])
@@ -141,7 +142,7 @@ def test_lance_filter_batches_cross_bitmap_chunk_boundary(tmp_path, monkeypatch)
 
 @pytest.mark.parametrize("shuffle_mode", ["none", "global", "chunk"])
 def test_lance_filter_supports_source_shuffle(tmp_path, monkeypatch, shuffle_mode: str) -> None:
-    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setenv("MVP_DATASET_CACHE_DIR", str(tmp_path / "cache"))
     source = write_lance_dataset(tmp_path, build_records(30), max_rows_per_file=4)
     chunk_shuffle = {"chunk_size": 4, "k": 2} if shuffle_mode == "chunk" else None
 
@@ -163,7 +164,7 @@ def test_lance_filter_supports_source_shuffle(tmp_path, monkeypatch, shuffle_mod
 
 
 def test_lance_filter_split_sample_and_resume(tmp_path, monkeypatch) -> None:
-    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setenv("MVP_DATASET_CACHE_DIR", str(tmp_path / "cache"))
     source = write_lance_dataset(tmp_path, build_records(40), max_rows_per_file=5)
     dataset = Dataset.from_source("lance", source, shuffle_mode="global").filter("value >= 10")
 
@@ -183,7 +184,7 @@ def test_lance_filter_split_sample_and_resume(tmp_path, monkeypatch) -> None:
 
 
 def test_lance_filter_preserves_multi_source_global_indexes(tmp_path, monkeypatch) -> None:
-    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setenv("MVP_DATASET_CACHE_DIR", str(tmp_path / "cache"))
     left_root = tmp_path / "left"
     right_root = tmp_path / "right"
     left_root.mkdir()
@@ -200,8 +201,7 @@ def test_lance_filter_preserves_multi_source_global_indexes(tmp_path, monkeypatc
 
 
 def test_lance_filter_resolve_ref_uses_original_global_indexes(tmp_path, monkeypatch) -> None:
-    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(tmp_path / "filter-cache"))
-    monkeypatch.setenv("MVP_DATASET_LANCE_REF_INDEX_CACHE_DIR", str(tmp_path / "ref-cache"))
+    monkeypatch.setenv("MVP_DATASET_CACHE_DIR", str(tmp_path / "cache"))
     main = write_lance_table(
         tmp_path,
         "main.lance",
@@ -218,7 +218,7 @@ def test_lance_filter_resolve_ref_uses_original_global_indexes(tmp_path, monkeyp
         ref_columns={"image": {"uri": refs, "key_column": "key", "value_column": "payload"}},
     ).filter("value IN (1, 4, 7)")
 
-    rows = list(dataset.resolve_ref(["image"], index={"scope": "process"}))
+    rows = list(dataset.resolve_ref(["image"]))
 
     assert [row["__global_index__"] for row in rows] == [1, 4, 7]
     assert [row["image"] for row in rows] == ["bytes-1", "bytes-4", "bytes-7"]
@@ -226,26 +226,34 @@ def test_lance_filter_resolve_ref_uses_original_global_indexes(tmp_path, monkeyp
 
 def test_lance_filter_cache_is_picklable_and_reused(tmp_path, monkeypatch) -> None:
     cache_dir = tmp_path / "cache"
-    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(cache_dir))
+    legacy_cache_dir = tmp_path / "legacy-filter-cache"
+    monkeypatch.setenv("MVP_DATASET_CACHE_DIR", str(cache_dir))
+    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(legacy_cache_dir))
     source = write_lance_dataset(tmp_path, build_records(20), max_rows_per_file=2)
     dataset = Dataset.from_source("lance", source).filter("value >= 5")
 
     pickle.dumps(dataset)
     assert _values(dataset) == list(range(5, 20))
     manifest = next(cache_dir.rglob("manifest.json"))
-    part_mtimes = {path.name: path.stat().st_mtime_ns for path in manifest.parent.glob("part-*.i64")}
+    part_mtimes = {
+        str(path.relative_to(manifest.parent)): path.stat().st_mtime_ns for path in manifest.parent.rglob("*.i64")
+    }
     assert len(part_mtimes) > 1
 
     assert _values(dataset) == list(range(5, 20))
-    assert {path.name: path.stat().st_mtime_ns for path in manifest.parent.glob("part-*.i64")} == part_mtimes
+    assert {
+        str(path.relative_to(manifest.parent)): path.stat().st_mtime_ns for path in manifest.parent.rglob("*.i64")
+    } == part_mtimes
     metadata = json.loads(manifest.read_text(encoding="utf-8"))
-    assert metadata["offsets"][-1] == 15
+    assert sum(part["metadata"]["count"] for part in metadata["metadata"]["parts"]) == 15
+    assert not legacy_cache_dir.exists()
+    assert not os.path.exists(os.path.join(source, "_mvp_filter_index"))
 
 
 def test_lance_filter_warm_cache_skips_fragment_planning(tmp_path, monkeypatch) -> None:
     from mvp_dataset.sources.lance import filter as lance_filter
 
-    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setenv("MVP_DATASET_CACHE_DIR", str(tmp_path / "cache"))
     source = write_lance_dataset(tmp_path, build_records(12), max_rows_per_file=2)
     dataset = Dataset.from_source("lance", source).filter("value >= 5")
     assert _values(dataset) == list(range(5, 12))
@@ -255,15 +263,15 @@ def test_lance_filter_warm_cache_skips_fragment_planning(tmp_path, monkeypatch) 
 
 
 def test_lance_filter_rebuilds_truncated_part(tmp_path, monkeypatch) -> None:
-    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setenv("MVP_DATASET_CACHE_DIR", str(tmp_path / "cache"))
     source = write_lance_dataset(tmp_path, build_records(20), max_rows_per_file=2)
     dataset = Dataset.from_source("lance", source).filter("value >= 5")
     assert _values(dataset) == list(range(5, 20))
 
     manifest_path = next((tmp_path / "cache").rglob("manifest.json"))
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    part = next(part for part in manifest["parts"] if part["count"] > 0)
-    part_path = manifest_path.parent / part["file"]
+    part = next(part for part in manifest["metadata"]["parts"] if part["metadata"]["count"] > 0)
+    part_path = manifest_path.parent / part["files"][0]
     with part_path.open("r+b") as handle:
         handle.truncate(part_path.stat().st_size - 8)
 
@@ -280,7 +288,7 @@ def test_lance_source_without_filter_does_not_enumerate_fragments(tmp_path, monk
 
 
 def test_lance_filter_handles_empty_results(tmp_path, monkeypatch) -> None:
-    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setenv("MVP_DATASET_CACHE_DIR", str(tmp_path / "cache"))
     source = write_lance_dataset(tmp_path, build_records(8), max_rows_per_file=2)
 
     dataset = Dataset.from_source("lance", source).filter("value < 0")
@@ -293,7 +301,7 @@ def test_lance_filter_validates_predicate_for_zero_fragment_source(tmp_path, mon
     import lance
     import pyarrow as pa
 
-    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setenv("MVP_DATASET_CACHE_DIR", str(tmp_path / "cache"))
     source = tmp_path / "empty.lance"
     lance.write_dataset(pa.table({"value": pa.array([], type=pa.int64())}), source)
 
@@ -306,8 +314,7 @@ def test_lance_filter_and_ref_index_use_discovered_version(tmp_path, monkeypatch
     import lance
     import pyarrow as pa
 
-    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(tmp_path / "filter-cache"))
-    monkeypatch.setenv("MVP_DATASET_LANCE_REF_INDEX_CACHE_DIR", str(tmp_path / "ref-cache"))
+    monkeypatch.setenv("MVP_DATASET_CACHE_DIR", str(tmp_path / "cache"))
     main = write_lance_table(
         tmp_path,
         "main.lance",
@@ -325,7 +332,7 @@ def test_lance_filter_and_ref_index_use_discovered_version(tmp_path, monkeypatch
             ref_columns={"image": {"uri": refs, "key_column": "key", "value_column": "payload"}},
         )
         .filter("value >= 0")
-        .resolve_ref(["image"], index={"scope": "process"})
+        .resolve_ref(["image"])
     )
     lance.write_dataset(pa.Table.from_pylist([{"id": 8, "value": 8, "image": "image-8"}]), main, mode="append")
 
@@ -338,7 +345,7 @@ def test_lance_ref_value_source_uses_discovered_version(tmp_path, monkeypatch) -
     import lance
     import pyarrow as pa
 
-    monkeypatch.setenv("MVP_DATASET_LANCE_REF_INDEX_CACHE_DIR", str(tmp_path / "ref-cache"))
+    monkeypatch.setenv("MVP_DATASET_CACHE_DIR", str(tmp_path / "cache"))
     main = write_lance_table(
         tmp_path,
         "main.lance",
@@ -353,7 +360,7 @@ def test_lance_ref_value_source_uses_discovered_version(tmp_path, monkeypatch) -
         "lance",
         main,
         ref_columns={"image": {"uri": refs, "key_column": "key", "value_column": "payload"}},
-    ).resolve_ref(["image"], index={"scope": "process"})
+    ).resolve_ref(["image"])
     reversed_refs = [{"key": f"image-{index}", "payload": f"changed-{index}"} for index in reversed(range(4))]
     lance.write_dataset(pa.Table.from_pylist(reversed_refs), refs, mode="overwrite")
 
@@ -364,7 +371,7 @@ def test_lance_ref_value_source_uses_discovered_version(tmp_path, monkeypatch) -
 def test_lance_filter_rejects_deleted_rows(tmp_path, monkeypatch) -> None:
     import lance
 
-    monkeypatch.setenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setenv("MVP_DATASET_CACHE_DIR", str(tmp_path / "cache"))
     source = write_lance_dataset(tmp_path, build_records(8), max_rows_per_file=2)
     lance.dataset(source).delete("value = 1")
 
@@ -389,7 +396,7 @@ def test_lance_filter_validates_api_and_placement(tmp_path) -> None:
         Dataset.from_source("lance", source).filter(["value > 0", "  "])
     with pytest.raises(ValueError, match="unknown config key"):
         Dataset.from_source("lance", source).filter("value > 0", index={"unknown": True})
-    with pytest.raises(ValueError, match="InvalidLanceFilterIndexScope"):
+    with pytest.raises(ValueError, match="unknown config key"):
         Dataset.from_source("lance", source).filter("value > 0", index={"scope": "unknown"})
     with pytest.raises(ValueError, match="InvalidFilterPlacement"):
         Dataset.from_source("lance", source).map(lambda row: row).filter("value > 0")
@@ -397,12 +404,13 @@ def test_lance_filter_validates_api_and_placement(tmp_path) -> None:
         Dataset.from_source("lance", source).split([1, 1])[0].filter("value > 0")
 
 
-def test_lance_filter_requires_cache_dir_for_uri_source(tmp_path, monkeypatch) -> None:
-    monkeypatch.delenv("MVP_DATASET_LANCE_FILTER_INDEX_CACHE_DIR", raising=False)
+def test_lance_filter_uri_source_uses_unified_cache_dir(tmp_path, monkeypatch) -> None:
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv("MVP_DATASET_CACHE_DIR", str(cache_dir))
     source = write_lance_dataset(tmp_path, build_records(8))
 
-    with pytest.raises(ValueError, match="MissingLanceFilterIndexCacheDir"):
-        list(Dataset.from_source("lance", f"file://{source}").filter("value > 0"))
+    assert _values(Dataset.from_source("lance", f"file://{source}").filter("value > 0")) == list(range(1, 8))
+    assert len(list(cache_dir.glob("*/lance-filter-index-v1/*"))) == 1
 
 
 @pytest.mark.parametrize(
@@ -426,10 +434,21 @@ def test_lance_filter_builds_shared_parts_across_builders(tmp_path, builders, fi
     cache_dir = tmp_path / "cache"
     context = multiprocessing.get_context("spawn")
     results = context.Queue()
+    start_barrier = context.Barrier(len(builders))
     processes = [
         context.Process(
             target=_distributed_filter_worker,
-            args=(source, str(cache_dir), filter_arg, rank, world_size, worker_id, num_workers, results),
+            args=(
+                source,
+                str(cache_dir),
+                filter_arg,
+                rank,
+                world_size,
+                worker_id,
+                num_workers,
+                start_barrier,
+                results,
+            ),
         )
         for rank, world_size, worker_id, num_workers in builders
     ]
@@ -453,6 +472,8 @@ def test_lance_filter_builds_shared_parts_across_builders(tmp_path, builders, fi
     assert not errors, "\n".join(errors)
     values = [value for status, payload in outputs if status == "ok" for value in payload["values"]]
     assert sorted(values) == expected
-    assert all(payload["built_parts"] for status, payload in outputs if status == "ok")
-    assert len(list(cache_dir.rglob("part-*.i64"))) > 1
+    builder_parts = [set(payload["built_parts"]) for status, payload in outputs if status == "ok"]
+    assert all(builder_parts)
+    assert builder_parts[0].isdisjoint(builder_parts[1])
+    assert len(builder_parts[0] | builder_parts[1]) == len(list(cache_dir.rglob("*.i64")))
     assert len(list(cache_dir.rglob("manifest.json"))) == 1

--- a/tests/test_reading.py
+++ b/tests/test_reading.py
@@ -72,6 +72,80 @@ def test_sources_shard_across_ranks(tmp_path, monkeypatch, source_kind: str) -> 
     assert {sample["id"] for sample in observed_rank0}.isdisjoint({sample["id"] for sample in observed_rank1})
 
 
+def test_jsonl_resume_and_sample_identity_ignore_mount_and_cache_roots(tmp_path, monkeypatch) -> None:
+    source_root = tmp_path / "source"
+    source_root.mkdir()
+    write_jsonl_file(source_root, build_records(count=8))
+    mount_a = tmp_path / "mount-a"
+    mount_b = tmp_path / "mount-b"
+    mount_a.symlink_to(source_root, target_is_directory=True)
+    mount_b.symlink_to(source_root, target_is_directory=True)
+    context = RuntimeContext(rank=0, world_size=2, seed=17)
+
+    monkeypatch.setenv("MVP_DATASET_CACHE_FINGERPRINT_MODE", "content")
+    monkeypatch.setenv("MVP_DATASET_CACHE_DIR", str(tmp_path / "cache-a"))
+    first_dataset = Dataset.from_source(
+        "jsonl",
+        str(mount_a / "samples.jsonl"),
+        context=context,
+        shuffle_mode="none",
+    )
+    first_iterator = iter(first_dataset)
+    first_sample = next(first_iterator)
+    state = first_iterator.state_dict()
+    expected_remainder = list(first_iterator)
+
+    monkeypatch.setenv("MVP_DATASET_CACHE_DIR", str(tmp_path / "cache-b"))
+    second_dataset = Dataset.from_source(
+        "jsonl",
+        str(mount_b / "samples.jsonl"),
+        context=context,
+        shuffle_mode="none",
+    )
+    with pytest.warns(UserWarning, match="Dataset.load_state_dict"):
+        resumed = second_dataset.load_state_dict(state)
+
+    assert list(resumed) == expected_remainder
+    assert first_dataset._pipeline_fingerprint() == second_dataset._pipeline_fingerprint()
+    assert first_sample["__file__"] == "samples.jsonl"
+    assert first_sample["__index_in_file__"] == 0
+    assert str(tmp_path / "cache-a") not in first_sample["__key__"]
+
+
+def test_jsonl_sample_identity_ignores_split_layout(tmp_path, monkeypatch) -> None:
+    source = write_jsonl_file(tmp_path, build_records(count=8))
+    monkeypatch.setenv("MVP_DATASET_CACHE_FINGERPRINT_MODE", "content")
+    monkeypatch.setenv("MVP_DATASET_CACHE_DIR", str(tmp_path / "cache"))
+
+    single = list(
+        Dataset.from_source(
+            "jsonl",
+            source,
+            context=RuntimeContext(world_size=1),
+            shuffle_mode="none",
+        )
+    )
+    distributed = [
+        sample
+        for rank in range(2)
+        for sample in Dataset.from_source(
+            "jsonl",
+            source,
+            context=RuntimeContext(rank=rank, world_size=2),
+            shuffle_mode="none",
+        )
+    ]
+
+    single_metadata = {
+        int(sample["value"]): (sample["__file__"], sample["__index_in_file__"], sample["__key__"]) for sample in single
+    }
+    distributed_metadata = {
+        int(sample["value"]): (sample["__file__"], sample["__index_in_file__"], sample["__key__"])
+        for sample in distributed
+    }
+    assert distributed_metadata == single_metadata
+
+
 @pytest.mark.parametrize(
     ("source_kind", "explicit_mode", "metadata_key"),
     [
@@ -357,7 +431,6 @@ def test_lance_bucketed_ref_index_loads_with_shuffle_modes(tmp_path, shuffle_mod
         ["image_ref"],
         resolve_batch_size=2,
         index={
-            "scope": "process",
             "build_strategy": "bucketed",
             "bucket_count": 2,
         },
@@ -368,7 +441,7 @@ def test_lance_bucketed_ref_index_loads_with_shuffle_modes(tmp_path, shuffle_mod
     assert [sample["image_ref"] for sample in observed] == [f"resolved-{index % 4}" for index in range(12)]
 
 
-def test_lance_ref_index_cache_dir_env(tmp_path, monkeypatch) -> None:
+def test_lance_ref_index_uses_unified_cache_dir(tmp_path, monkeypatch) -> None:
     pytest.importorskip("lance")
 
     main_path = write_lance_table(
@@ -381,8 +454,10 @@ def test_lance_ref_index_cache_dir_env(tmp_path, monkeypatch) -> None:
         "refs.lance",
         [{"image_id": f"img-{index}", "image_value": f"resolved-{index}"} for index in range(3)],
     )
-    cache_dir = tmp_path / "ref-index-cache"
-    monkeypatch.setenv("MVP_DATASET_LANCE_REF_INDEX_CACHE_DIR", str(cache_dir))
+    cache_dir = tmp_path / "mvp-cache"
+    legacy_cache_dir = tmp_path / "legacy-ref-index-cache"
+    monkeypatch.setenv("MVP_DATASET_CACHE_DIR", str(cache_dir))
+    monkeypatch.setenv("MVP_DATASET_LANCE_REF_INDEX_CACHE_DIR", str(legacy_cache_dir))
 
     dataset = Dataset.from_source(
         "lance",
@@ -397,9 +472,37 @@ def test_lance_ref_index_cache_dir_env(tmp_path, monkeypatch) -> None:
     ).resolve_ref(
         ["image_ref"],
         resolve_batch_size=2,
-        index={"scope": "process", "build_strategy": "in_memory"},
+        index={"build_strategy": "in_memory"},
     )
 
     assert [sample["image_ref"] for sample in dataset] == [f"resolved-{index}" for index in range(3)]
-    assert list(cache_dir.glob("ref-index-*"))
+    entries = list(cache_dir.glob("*/lance-ref-index-v1/*"))
+    assert len(entries) == 1
+    assert (entries[0] / "manifest.json").is_file()
+    assert (entries[0] / "complete").is_file()
+    assert not legacy_cache_dir.exists()
     assert not (tmp_path / "main.lance" / "_mvp_ref_index").exists()
+
+
+def test_lance_ref_index_rejects_removed_scope_config(tmp_path) -> None:
+    pytest.importorskip("lance")
+    main_path = write_lance_table(tmp_path, "main.lance", [{"id": "sample", "image_ref": "image"}])
+    ref_path = write_lance_table(
+        tmp_path,
+        "refs.lance",
+        [{"image_id": "image", "image_value": "resolved"}],
+    )
+    dataset = Dataset.from_source(
+        "lance",
+        shards=main_path,
+        ref_columns={
+            "image_ref": {
+                "uri": ref_path,
+                "key_column": "image_id",
+                "value_column": "image_value",
+            }
+        },
+    )
+
+    with pytest.raises(ValueError, match=r"\[InvalidLanceRefIndexConfig\].*scope"):
+        dataset.resolve_ref(["image_ref"], index={"scope": "shared"})

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -459,7 +459,6 @@ def test_lance_shuffle_resume_with_and_without_resolve_ref(
             ["image_ref"],
             resolve_batch_size=3,
             index={
-                "scope": "process",
                 "build_strategy": "bucketed",
                 "bucket_count": 3,
             },


### PR DESCRIPTION
## Purpose

Unify persistent cache management for derived dataset artifacts and remove source-specific, path-dependent cache layouts.

## Key changes

- Add a centralized `CacheManager.ensure()` API for whole-artifact and partitioned builds.
- Add mount-independent source fingerprints and configurable cache roots.
- Publish completed artifacts atomically and use `flock`-backed leases so crashed builders cannot expose partial caches or delete a newer builder's lease.
- Migrate JSONL splitting, Lance reference indexes, and Lance filter caches to the unified API.
- Preserve distributed Lance filter construction while deriving part ordering internally.
- Keep JSONL sample identity independent of physical mount and cache paths.
- Add cache inspection/cleanup APIs, documentation, and concurrency/crash-recovery coverage.

## Root cause

Cache ownership, keys, paths, locking, and publication were implemented independently by each source. This made caches sensitive to mount paths and allowed incomplete or stale build state to leak into later reads.

## Configuration impact

- `MVP_DATASET_CACHE_DIR` selects the unified cache root.
- `MVP_DATASET_CACHE_FINGERPRINT_MODE` selects metadata or content fingerprinting.
- Legacy source-adjacent cache locations and cache options are intentionally not supported.
- Shared cache filesystems must provide POSIX `flock` semantics.

## Validation

- `.venv/bin/pytest -q -k 'not test_loader_stage_pipeline_is_deterministic and not test_stage_objects_are_picklable'` — 167 passed, 16 skipped, 2 deselected
- `.venv/bin/pytest tests/test_cache.py -q` — 18 passed
- `.venv/bin/ruff check src tests`
- `.venv/bin/ruff format --check src tests`
- `.venv/bin/python -m compileall -q src tests`
- pre-commit hooks: ruff check, ruff format, isort
