### PR TITLE
fix: preserve sparse balance tails

### DIFF
--- a/src/mvp_dataset/loader/stages/balance.py
+++ b/src/mvp_dataset/loader/stages/balance.py
@@ -331,8 +331,10 @@ def plan_balance_chunk(
                     remaining[rank] -= 1
                 else:
                     dummy_counts[rank] += 1
-            finished = all(status.upstream_done for status in ordered)
-            break
+            if not any(remaining.values()):
+                finished = all(status.upstream_done for status in ordered)
+                break
+            continue
 
         deficits: list[int] = []
         for rank in ranks:

--- a/tests/test_balance.py
+++ b/tests/test_balance.py
@@ -114,6 +114,21 @@ def test_balance_planner_handles_tail_drop_and_dummy() -> None:
     assert dummy_plan.finished_after_chunk
 
 
+def test_balance_planner_consumes_sparse_tail_without_dropping_items() -> None:
+    plan = plan_balance_chunk(
+        [_status(rank, 3 if rank == 0 else 0) for rank in range(8)],
+        chunk_size=16,
+        max_transfer_per_round=8,
+        drop_last=False,
+        topology="none",
+    )
+
+    assert plan.local_take == {rank: 3 if rank == 0 else 0 for rank in range(8)}
+    assert plan.transfers == []
+    assert plan.dummy_counts == {rank: 0 if rank == 0 else 3 for rank in range(8)}
+    assert plan.finished_after_chunk
+
+
 def test_balance_api_validation_and_resume_rejection() -> None:
     if torch is None:
         pytest.skip("torch is not installed")
@@ -225,6 +240,21 @@ def test_balance_distributed_dummy_tail(tmp_path) -> None:
 
     assert [len(items) for items in outputs.values()] == [4, 4]
     assert sum(int(item["dummy"]) for items in outputs.values() for item in items) == 1
+
+
+@pytest.mark.skipif(dist is None or mp is None, reason="torch distributed is not installed")
+def test_balance_distributed_sparse_tail_preserves_real_items(tmp_path) -> None:
+    outputs = _run_balance_spawn(tmp_path, counts=[3, 0, 0, 0], drop_last=False, chunk_size=2)
+
+    assert [len(items) for items in outputs.values()] == [3, 3, 3, 3]
+    real_items = [
+        (item["source_rank"], item["index"])
+        for items in outputs.values()
+        for item in items
+        if not item["dummy"]
+    ]
+    assert sorted(real_items) == [(0, 0), (0, 1), (0, 2)]
+    assert sum(int(item["dummy"]) for items in outputs.values() for item in items) == 9
 
 
 @pytest.mark.skipif(dist is None or mp is None, reason="torch distributed is not installed")


### PR DESCRIPTION
Fix #25 `balance(drop_last=False)` so sparse distributed tails continue until all real buffered items are consumed instead of terminating after one padded step.

BTW, sharding guarantees that global worker slots differ by at most one item, but balance operates after workers are merged per rank. Therefore, rank-level counts can differ by up to `num_workers`.

For example, with 8 ranks, 2 workers per rank, and 6,324 packs, the 16 worker slots receive `[396, 396, 396, 396, 395, ...]`. After merging workers, rank counts become `[792, 792, 790, ...]`, leaving a tail of `[2, 2, 0, ...]`. The old planner consumed one item from each non-empty rank and silently dropped the remaining two.

